### PR TITLE
Implement route detail panel

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -5,6 +5,7 @@ await mkdir("dist/data", { recursive: true });
 await copyFile("src/index.html", "dist/index.html");
 await copyFile("src/styles.css", "dist/styles.css");
 await copyFile("src/route-styles.mjs", "dist/route-styles.mjs");
+await copyFile("src/route-details.mjs", "dist/route-details.mjs");
 await copyFile("src/app.mjs", "dist/app.mjs");
 await copyFile("src/route-map.mjs", "dist/route-map.mjs");
 await copyFile("data/pilot-routes.json", "dist/data/pilot-routes.json");

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -11,6 +11,7 @@ const sourceInventory = JSON.parse(
 );
 const packageJson = JSON.parse(await readFile("package.json", "utf8"));
 const { styleRouteForMap } = await import("../src/route-styles.mjs");
+const { formatRouteDetail } = await import("../src/route-details.mjs");
 
 assert.deepEqual(routeContract.requiredFields, [
   "route_id",
@@ -146,6 +147,77 @@ const completeRouteRecord = {
   provenance_notes: "Prototype fixture for route contract validation.",
   uncertainty_notes: "Open MVP evidence questions remain unresolved.",
 };
+
+const supportingRouteDetail = formatRouteDetail({
+  ...completeRouteRecord,
+  route_name: "Two Tunnels and Colliers Way source corridor",
+  corridor_name: "Bath to Somer Valley",
+  network_status: "supporting",
+  network_role: "greenway-strategic-link",
+  modal_shift_potential: "medium",
+  age12_standard_target: "partial-after-intervention",
+  school_access_relevance: "low",
+  broad_intervention_need: "existing-route-may-be-sufficient",
+  why_this_route_matters:
+    "This route keeps strategic greenway context visible for review.",
+  what_needs_review:
+    "Review whether its role is leisure, utility, strategic, or mixed.",
+  evidence_notes: "Greenway evidence is useful context, not a final decision.",
+  provenance_notes: "Uses reviewed public source inventory entries.",
+});
+
+assert.deepEqual(supportingRouteDetail.summary, {
+  title: "Two Tunnels and Colliers Way source corridor",
+  corridor: "Bath to Somer Valley",
+  networkStatus: "Supporting route",
+  networkRole: "Greenway strategic link",
+  modalShiftPotential: "Medium modal shift potential",
+  age12Target: "Partial after intervention",
+  schoolAccessRelevance: "Low school access relevance",
+  broadInterventionNeed: "Existing route may be sufficient",
+});
+assert.equal(
+  supportingRouteDetail.whyThisRouteMatters,
+  "This route keeps strategic greenway context visible for review.",
+);
+assert.equal(
+  supportingRouteDetail.whatNeedsReview,
+  "Review whether its role is leisure, utility, strategic, or mixed.",
+);
+assert.deepEqual(supportingRouteDetail.notes, [
+  "Greenway evidence is useful context, not a final decision.",
+  "Uses reviewed public source inventory entries.",
+  "Open MVP evidence questions remain unresolved.",
+]);
+
+const routeStatusCaveats = routeContract.allowedValues.network_status.map(
+  (network_status) => [
+    network_status,
+    formatRouteDetail({
+      ...completeRouteRecord,
+      network_status,
+    }).statusCaveat,
+  ],
+);
+
+assert.deepEqual(routeStatusCaveats, [
+  [
+    "preferred",
+    "Preferred in this simplified layer means a candidate investment priority for review; it does not mean the route is already safe or usable today.",
+  ],
+  [
+    "supporting",
+    "Supporting route means useful network context or connection; it is separate from a preferred investment status.",
+  ],
+  [
+    "not-preferred",
+    "Not preferred in this simplified layer means the prototype is not prioritising this route; it does not delete source evidence or make a final route decision.",
+  ],
+  [
+    "needs-review",
+    "Needs review means the available evidence is not enough to assign a stronger prototype status.",
+  ],
+]);
 
 const atmBackgroundStyle = styleRouteForMap({
   ...completeRouteRecord,
@@ -291,10 +363,15 @@ for (const route of pilotRoutes.filter(
 }
 const { renderRouteMap } = await import("../src/route-map.mjs");
 const renderedRouteMap = renderRouteMap(pilotRoutes);
+const renderedSelectedRouteMap = renderRouteMap(pilotRoutes, {
+  selectedRouteId: "prototype-a367-utility-corridor-hypothesis",
+});
 assert.match(renderedRouteMap, /Original ATM-style source evidence/i);
 assert.match(renderedRouteMap, /Simplified prototype layer/i);
 assert.match(renderedRouteMap, /data-route-layer="atm-background"/i);
 assert.match(renderedRouteMap, /data-route-layer="prototype-simplified"/i);
+assert.match(renderedRouteMap, /<button[^>]+data-route-id="/i);
+assert.match(renderedRouteMap, /aria-controls="route-detail"/i);
 assert.match(renderedRouteMap, /--route-stroke:#b8c2cc/i);
 assert.match(renderedRouteMap, /--route-opacity:0\.45/i);
 assert.match(renderedRouteMap, /data-route-status-label="Needs review"/i);
@@ -312,6 +389,23 @@ assert.match(renderedRouteMap, /not a final preferred alignment/i);
 assert.match(renderedRouteMap, /Route data:/i);
 assert.match(renderedRouteMap, /checked-in pilot dataset/i);
 assert.match(renderedRouteMap, /B&amp;NES Active Travel Masterplan source context/i);
+
+assert.match(renderedSelectedRouteMap, /id="route-detail"/i);
+assert.match(renderedSelectedRouteMap, /A367 utility-corridor hypothesis/i);
+assert.match(renderedSelectedRouteMap, /Needs review/i);
+assert.match(renderedSelectedRouteMap, /Utility spine/i);
+assert.match(renderedSelectedRouteMap, /Unknown modal shift potential/i);
+assert.match(
+  renderedSelectedRouteMap,
+  /Unknown age-12 independent travel target/i,
+);
+assert.match(renderedSelectedRouteMap, /Unknown school access relevance/i);
+assert.match(renderedSelectedRouteMap, /Officer review needed/i);
+assert.match(renderedSelectedRouteMap, /Why this route matters/i);
+assert.match(renderedSelectedRouteMap, /What needs review/i);
+assert.match(renderedSelectedRouteMap, /Evidence and provenance/i);
+assert.match(renderedSelectedRouteMap, /not a final preferred alignment/i);
+assert.doesNotMatch(renderedSelectedRouteMap, /final route decision/i);
 
 const pilotRoutesText = JSON.stringify(pilotRoutes);
 assert.doesNotMatch(
@@ -376,6 +470,7 @@ execFileSync("npm", ["run", "build"], { stdio: "pipe" });
 assert.equal(existsSync("dist/index.html"), true);
 assert.equal(existsSync("dist/styles.css"), true);
 assert.equal(existsSync("dist/route-styles.mjs"), true);
+assert.equal(existsSync("dist/route-details.mjs"), true);
 assert.equal(existsSync("dist/app.mjs"), true);
 assert.equal(existsSync("dist/route-map.mjs"), true);
 assert.equal(existsSync("dist/data/pilot-routes.json"), true);
@@ -390,6 +485,9 @@ const clientScript = await readFile("dist/app.mjs", "utf8");
 assert.match(clientScript, /import \{ renderRouteMap \}/i);
 assert.match(clientScript, /pilot-routes\.json/i);
 assert.match(clientScript, /innerHTML\s*=\s*renderRouteMap/i);
+assert.match(clientScript, /addEventListener\("click"/i);
+assert.match(clientScript, /closest\("\[data-route-id\]"\)/i);
+assert.match(clientScript, /selectedRouteId/i);
 
 assert.match(
   visibleText,
@@ -412,6 +510,8 @@ assert.match(visibleText, /wider lines indicate stronger potential/i);
 const styles = await readFile("dist/styles.css", "utf8");
 assert.match(styles, /route-layer-background[\s\S]*opacity:\s*0\.[0-9]+/i);
 assert.match(styles, /route-layer-prototype[\s\S]*border-left:\s*[4-9]px/i);
+assert.match(styles, /route-line[\s\S]*cursor:\s*pointer/i);
+assert.match(styles, /route-detail-panel/i);
 assert.match(styles, /map-attribution/i);
 
 assert.equal(existsSync("README.md"), true);

--- a/src/app.mjs
+++ b/src/app.mjs
@@ -6,5 +6,21 @@ const routeMap = document.querySelector("#route-map");
 if (routeMap) {
   const response = await fetch(routeDatasetUrl);
   const routes = await response.json();
-  routeMap.innerHTML = renderRouteMap(routes);
+  let selectedRouteId = null;
+
+  function renderSelectedRouteMap() {
+    routeMap.innerHTML = renderRouteMap(routes, { selectedRouteId });
+  }
+
+  routeMap.addEventListener("click", (event) => {
+    const routeControl = event.target.closest("[data-route-id]");
+    if (!routeControl) {
+      return;
+    }
+
+    selectedRouteId = routeControl.dataset.routeId;
+    renderSelectedRouteMap();
+  });
+
+  renderSelectedRouteMap();
 }

--- a/src/route-details.mjs
+++ b/src/route-details.mjs
@@ -1,0 +1,100 @@
+const labels = {
+  network_status: {
+    preferred: "Preferred in simplified layer",
+    supporting: "Supporting route",
+    "not-preferred": "Not preferred in simplified layer",
+    "needs-review": "Needs review",
+  },
+  network_role: {
+    "utility-spine": "Utility spine",
+    "settlement-connector": "Settlement connector",
+    "school-access-link": "School access link",
+    "greenway-strategic-link": "Greenway strategic link",
+    "leisure-tourism-link": "Leisure and tourism link",
+    "bus-corridor-access": "Bus corridor access",
+    "gap-filler": "Gap filler",
+    "local-feeder": "Local feeder",
+    unknown: "Unknown network role",
+  },
+  modal_shift_potential: {
+    high: "High modal shift potential",
+    medium: "Medium modal shift potential",
+    low: "Low modal shift potential",
+    unknown: "Unknown modal shift potential",
+  },
+  age12_standard_target: {
+    "likely-after-intervention": "Likely after intervention",
+    "partial-after-intervention": "Partial after intervention",
+    "unlikely-without-major-change": "Unlikely without major change",
+    "already-good-enough": "Already good enough",
+    unknown: "Unknown age-12 independent travel target",
+  },
+  school_access_relevance: {
+    high: "High school access relevance",
+    medium: "Medium school access relevance",
+    low: "Low school access relevance",
+    unknown: "Unknown school access relevance",
+  },
+  broad_intervention_need: {
+    "existing-route-may-be-sufficient": "Existing route may be sufficient",
+    "upgrade-likely-needed": "Upgrade likely needed",
+    "new-or-substantially-improved-route-likely-needed":
+      "New or substantially improved route likely needed",
+    "officer-review-needed": "Officer review needed",
+    unknown: "Unknown intervention need",
+  },
+};
+
+const statusCaveats = {
+  preferred:
+    "Preferred in this simplified layer means a candidate investment priority for review; it does not mean the route is already safe or usable today.",
+  supporting:
+    "Supporting route means useful network context or connection; it is separate from a preferred investment status.",
+  "not-preferred":
+    "Not preferred in this simplified layer means the prototype is not prioritising this route; it does not delete source evidence or make a final route decision.",
+  "needs-review":
+    "Needs review means the available evidence is not enough to assign a stronger prototype status.",
+};
+
+export function formatRouteDetail(route) {
+  return {
+    summary: {
+      title: route.route_name,
+      corridor: route.corridor_name,
+      networkStatus: labelFor(route, "network_status"),
+      networkRole: labelFor(route, "network_role"),
+      modalShiftPotential: labelFor(route, "modal_shift_potential"),
+      age12Target: labelFor(route, "age12_standard_target"),
+      schoolAccessRelevance: labelFor(route, "school_access_relevance"),
+      broadInterventionNeed: labelFor(route, "broad_intervention_need"),
+    },
+    statusCaveat: statusCaveatFor(route),
+    whyThisRouteMatters: route.why_this_route_matters,
+    whatNeedsReview: route.what_needs_review,
+    notes: [
+      route.evidence_notes,
+      route.provenance_notes,
+      route.uncertainty_notes,
+    ].filter((note) => typeof note === "string" && note.trim() !== ""),
+  };
+}
+
+function statusCaveatFor(route) {
+  const caveat = statusCaveats[route.network_status];
+  if (!caveat) {
+    throw new RangeError(
+      `Unsupported network_status value "${route.network_status}"`,
+    );
+  }
+
+  return caveat;
+}
+
+function labelFor(route, field) {
+  const label = labels[field]?.[route[field]];
+  if (!label) {
+    throw new RangeError(`Unsupported ${field} value "${route[field]}"`);
+  }
+
+  return label;
+}

--- a/src/route-map.mjs
+++ b/src/route-map.mjs
@@ -1,33 +1,39 @@
+import { formatRouteDetail } from "./route-details.mjs";
 import { styleRouteForMap } from "./route-styles.mjs";
 
-export function renderRouteMap(routes) {
+export function renderRouteMap(routes, options = {}) {
   const backgroundRoutes = routes.filter(
     (route) => route.route_layer === "atm-background",
   );
   const prototypeRoutes = routes.filter(
     (route) => route.route_layer === "prototype-simplified",
   );
+  const selectedRoute = routes.find(
+    (route) => route.route_id === options.selectedRouteId,
+  );
 
   return [
     "<section class=\"route-map\" aria-label=\"Pilot route map\">",
     "<div class=\"route-layer route-layer-background\" data-route-layer=\"atm-background\">",
     "<h2>Original ATM-style source evidence</h2>",
-    ...backgroundRoutes.map(renderRoute),
+    ...backgroundRoutes.map((route) => renderRoute(route, selectedRoute)),
     "</div>",
     "<div class=\"route-layer route-layer-prototype\" data-route-layer=\"prototype-simplified\">",
     "<h2>Simplified prototype layer</h2>",
-    ...prototypeRoutes.map(renderRoute),
+    ...prototypeRoutes.map((route) => renderRoute(route, selectedRoute)),
     "</div>",
+    renderRouteDetail(selectedRoute),
     "<footer class=\"map-attribution\">Route data: checked-in pilot dataset. B&amp;NES Active Travel Masterplan source context retained as background evidence.</footer>",
     "</section>",
   ].join("");
 }
 
-function renderRoute(route) {
+function renderRoute(route, selectedRoute) {
   const style = styleRouteForMap(route);
+  const isSelected = selectedRoute?.route_id === route.route_id;
 
   return [
-    "<article class=\"route-line\" style=\"",
+    "<button class=\"route-line\" type=\"button\" style=\"",
     renderRouteStyle(style),
     "\" data-route-id=\"",
     escapeHtml(route.route_id),
@@ -35,6 +41,8 @@ function renderRoute(route) {
     escapeHtml(style.statusLabel ?? "Original ATM-style source evidence"),
     "\" data-modal-shift-label=\"",
     escapeHtml(style.modalShiftLabel ?? "Background evidence"),
+    "\" aria-controls=\"route-detail\" aria-pressed=\"",
+    isSelected ? "true" : "false",
     "\">",
     "<h3>",
     escapeHtml(route.route_name),
@@ -47,7 +55,72 @@ function renderRoute(route) {
     "<p>",
     escapeHtml(route.route_geometry_notes),
     "</p>",
-    "</article>",
+    "</button>",
+  ].join("");
+}
+
+function renderRouteDetail(route) {
+  if (!route) {
+    return [
+      "<aside class=\"route-detail-panel route-detail-empty\" id=\"route-detail\" aria-label=\"Route detail panel\">",
+      "<h2>Route details</h2>",
+      "<p>Select a route to review its status, role, evidence notes, and unresolved questions.</p>",
+      "</aside>",
+    ].join("");
+  }
+
+  const detail = formatRouteDetail(route);
+  const summaryRows = [
+    ["Proposed network status", detail.summary.networkStatus],
+    ["Network role", detail.summary.networkRole],
+    ["Modal shift potential", detail.summary.modalShiftPotential],
+    ["Age-12 independent travel target", detail.summary.age12Target],
+    ["School access relevance", detail.summary.schoolAccessRelevance],
+    ["Broad intervention need", detail.summary.broadInterventionNeed],
+  ];
+
+  return [
+    "<aside class=\"route-detail-panel\" id=\"route-detail\" aria-label=\"Route detail panel\">",
+    "<p class=\"route-detail-eyebrow\">Route detail</p>",
+    "<h2>",
+    escapeHtml(detail.summary.title),
+    "</h2>",
+    "<p class=\"route-detail-corridor\">",
+    escapeHtml(detail.summary.corridor),
+    "</p>",
+    "<dl>",
+    ...summaryRows.map(renderSummaryRow),
+    "</dl>",
+    "<h3>How to read this status</h3>",
+    "<p>",
+    escapeHtml(detail.statusCaveat),
+    "</p>",
+    "<h3>Why this route matters</h3>",
+    "<p>",
+    escapeHtml(detail.whyThisRouteMatters),
+    "</p>",
+    "<h3>What needs review</h3>",
+    "<p>",
+    escapeHtml(detail.whatNeedsReview),
+    "</p>",
+    "<h3>Evidence and provenance</h3>",
+    "<ul>",
+    ...detail.notes.map((note) => `<li>${escapeHtml(note)}</li>`),
+    "</ul>",
+    "</aside>",
+  ].join("");
+}
+
+function renderSummaryRow([term, description]) {
+  return [
+    "<div>",
+    "<dt>",
+    escapeHtml(term),
+    "</dt>",
+    "<dd>",
+    escapeHtml(description),
+    "</dd>",
+    "</div>",
   ].join("");
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -222,10 +222,22 @@ h3 {
   display: grid;
   gap: 6px;
   padding: 12px 14px;
+  border: 0;
   border-radius: 8px;
   background: #ffffff;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
   opacity: var(--route-opacity, 1);
   order: var(--route-layer-order, 0);
+  text-align: left;
+}
+
+.route-line:hover,
+.route-line:focus-visible,
+.route-line[aria-pressed="true"] {
+  outline: 2px solid #0b5cad;
+  outline-offset: 2px;
 }
 
 .route-line h3 {
@@ -258,6 +270,72 @@ h3 {
   border-left-style: var(--route-stroke-style, solid);
   border-left-width: var(--route-stroke-width, 6px);
   box-shadow: 0 8px 18px rgba(0, 114, 178, 0.12);
+}
+
+.route-detail-panel {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid #d7e0e7;
+  border-radius: 8px;
+  background: #f8fbfc;
+}
+
+.route-detail-panel h2,
+.route-detail-panel h3,
+.route-detail-panel p,
+.route-detail-panel dl,
+.route-detail-panel ul {
+  margin: 0;
+}
+
+.route-detail-eyebrow {
+  color: #0b5cad;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.route-detail-corridor {
+  color: #52616f;
+  font-weight: 700;
+}
+
+.route-detail-panel dl {
+  display: grid;
+  gap: 8px;
+}
+
+.route-detail-panel dl div {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.8fr) minmax(0, 1fr);
+  gap: 10px;
+  padding-top: 8px;
+  border-top: 1px solid #e5edf2;
+}
+
+.route-detail-panel dt {
+  color: #52616f;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.route-detail-panel dd {
+  margin: 0;
+  color: #17202a;
+  font-weight: 700;
+}
+
+.route-detail-panel ul {
+  display: grid;
+  gap: 8px;
+  padding-left: 18px;
+  color: #425466;
+  line-height: 1.45;
+}
+
+.route-detail-empty {
+  color: #52616f;
 }
 
 .map-attribution {


### PR DESCRIPTION
## Summary
- Add a route detail formatter with cautious status labels and evidence notes.
- Render selectable route controls and a route detail panel for selected pilot routes.
- Copy the new module in the static build and extend tests for formatting, selection output, and styling.

## Test Plan
- [x] npm test
- [x] npm run build
- [x] git diff --check