### PR TITLE
Add pilot destination context

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ evidence has been added.
 npm test
 npm run build
 npm run validate:sources
+npm run validate:destinations
 ```
 
 The build output is written to `dist/`.
@@ -93,3 +94,20 @@ npm run validate:sources
 The inventory must distinguish official source evidence from advisory context,
 keep hypotheses marked as hypotheses, and identify which sources are safe enough
 for the first prototype dataset.
+
+## Pilot Destination Dataset
+
+The pilot destination dataset lives in `data/pilot-destinations.json`. It adds
+school and key-destination context for the Bath to Somer Valley pilot without
+attempting full catchment modelling.
+
+Validate it locally with:
+
+```sh
+npm run validate:destinations
+```
+
+Destination records must include source IDs, provenance notes, uncertainty
+notes, and claim limits. Indicative destination context must remain labelled as
+indicative or unknown, and the dataset must make no school-run impact,
+catchment coverage, route preference, or quantified modal-shift claims.

--- a/data/pilot-destinations.json
+++ b/data/pilot-destinations.json
@@ -1,0 +1,41 @@
+[
+  {
+    "destination_id": "somer-valley-education-destinations",
+    "destination_name": "Somer Valley education destinations",
+    "destination_type": "school-cluster",
+    "pilot_area": "Bath to Somer Valley",
+    "destination_status": "indicative-source-context",
+    "location_status": "indicative",
+    "display_position": {
+      "x": 68,
+      "y": 62
+    },
+    "source_ids": ["dfe-get-information-about-schools", "os-open-names"],
+    "related_route_ids": ["prototype-somer-valley-school-access-review"],
+    "school_access_relevance": "high",
+    "provenance_notes": "Use DfE school records and OS Open Names place context before replacing this cluster with establishment-level markers.",
+    "uncertainty_notes": "This is an indicative school-access cluster for MVP review, not a catchment, pupil-flow, or school-run impact model.",
+    "claim_limits": "destination context only; no school-run impact; no catchment coverage; no route preference; no quantified modal-shift claims"
+  },
+  {
+    "destination_id": "radstock-midsomer-norton-centres",
+    "destination_name": "Radstock and Midsomer Norton centre context",
+    "destination_type": "settlement-centre",
+    "pilot_area": "Bath to Somer Valley",
+    "destination_status": "indicative-source-context",
+    "location_status": "indicative",
+    "display_position": {
+      "x": 62,
+      "y": 72
+    },
+    "source_ids": ["os-open-names"],
+    "related_route_ids": [
+      "prototype-a367-utility-corridor-hypothesis",
+      "prototype-greenway-utility-comparison"
+    ],
+    "school_access_relevance": "unknown",
+    "provenance_notes": "Use OS Open Names place context for settlement-centre labelling before replacing this cluster with more precise destination records.",
+    "uncertainty_notes": "This is indicative place context only; it does not prove route usefulness, destination catchment, or modal-shift potential.",
+    "claim_limits": "destination context only; no school-run impact; no catchment coverage; no route preference; no quantified modal-shift claims"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node scripts/build.mjs",
     "test": "node scripts/test.mjs",
     "validate:routes": "node scripts/validate-routes.mjs",
-    "validate:sources": "node scripts/validate-source-inventory.mjs"
+    "validate:sources": "node scripts/validate-source-inventory.mjs",
+    "validate:destinations": "node scripts/validate-destinations.mjs"
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -9,3 +9,4 @@ await copyFile("src/route-details.mjs", "dist/route-details.mjs");
 await copyFile("src/app.mjs", "dist/app.mjs");
 await copyFile("src/route-map.mjs", "dist/route-map.mjs");
 await copyFile("data/pilot-routes.json", "dist/data/pilot-routes.json");
+await copyFile("data/pilot-destinations.json", "dist/data/pilot-destinations.json");

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -77,7 +77,13 @@ assert.equal(
   "node scripts/validate-source-inventory.mjs",
 );
 
+assert.equal(
+  packageJson.scripts["validate:destinations"],
+  "node scripts/validate-destinations.mjs",
+);
+
 execFileSync("npm", ["run", "validate:sources"], { stdio: "pipe" });
+execFileSync("npm", ["run", "validate:destinations"], { stdio: "pipe" });
 
 assert.equal(sourceInventory.pilot_area, "Bath to Somer Valley");
 assert.equal(sourceInventory.review_status, "reviewed-for-mvp");
@@ -128,6 +134,24 @@ function validationFailure(routeFile) {
   assert.fail(`Expected route validation to fail for ${routeFile}`);
 }
 
+function validateDestinations(destinationFile) {
+  return execFileSync("node", ["scripts/validate-destinations.mjs", destinationFile], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function destinationValidationFailure(destinationFile) {
+  try {
+    validateDestinations(destinationFile);
+  } catch (error) {
+    assert.notEqual(error.status, 0);
+    return error.stderr;
+  }
+
+  assert.fail(`Expected destination validation to fail for ${destinationFile}`);
+}
+
 const completeRouteRecord = {
   route_id: "bath-somer-valley-pilot",
   route_name: "Bath to Somer Valley pilot corridor",
@@ -146,6 +170,28 @@ const completeRouteRecord = {
   evidence_notes: "No final evidence conclusion has been encoded.",
   provenance_notes: "Prototype fixture for route contract validation.",
   uncertainty_notes: "Open MVP evidence questions remain unresolved.",
+};
+
+const completeDestinationRecord = {
+  destination_id: "somer-valley-education-destinations",
+  destination_name: "Somer Valley education destinations",
+  destination_type: "school-cluster",
+  pilot_area: "Bath to Somer Valley",
+  destination_status: "indicative-source-context",
+  location_status: "indicative",
+  display_position: {
+    x: 68,
+    y: 62,
+  },
+  source_ids: ["dfe-get-information-about-schools", "os-open-names"],
+  related_route_ids: ["prototype-somer-valley-school-access-review"],
+  school_access_relevance: "high",
+  provenance_notes:
+    "Use DfE school records and OS Open Names before replacing this cluster.",
+  uncertainty_notes:
+    "This is destination context only, not catchment analysis.",
+  claim_limits:
+    "destination context only; no school-run impact; no catchment coverage; no route preference; no quantified modal-shift claims",
 };
 
 const supportingRouteDetail = formatRouteDetail({
@@ -321,17 +367,90 @@ await writeFile(
 
 validateRoutes("tmp-route-tests/valid-routes.json");
 
+await writeFile(
+  "tmp-route-tests/valid-destinations.json",
+  `${JSON.stringify([completeDestinationRecord], null, 2)}\n`,
+);
+
+validateDestinations("tmp-route-tests/valid-destinations.json");
+
+const destinationWithoutProvenance = { ...completeDestinationRecord };
+delete destinationWithoutProvenance.provenance_notes;
+
+await writeFile(
+  "tmp-route-tests/destination-missing-provenance.json",
+  `${JSON.stringify([destinationWithoutProvenance], null, 2)}\n`,
+);
+
+assert.match(
+  destinationValidationFailure(
+    "tmp-route-tests/destination-missing-provenance.json",
+  ),
+  /provenance_notes/,
+);
+
+const destinationWithUnknownSource = {
+  ...completeDestinationRecord,
+  source_ids: ["unknown-source"],
+};
+
+await writeFile(
+  "tmp-route-tests/destination-unknown-source.json",
+  `${JSON.stringify([destinationWithUnknownSource], null, 2)}\n`,
+);
+
+assert.match(
+  destinationValidationFailure("tmp-route-tests/destination-unknown-source.json"),
+  /unknown-source/,
+);
+
+const destinationWithUnsafeSource = {
+  ...completeDestinationRecord,
+  source_ids: ["dft-bus-open-data-service"],
+};
+
+await writeFile(
+  "tmp-route-tests/destination-unsafe-source.json",
+  `${JSON.stringify([destinationWithUnsafeSource], null, 2)}\n`,
+);
+
+assert.match(
+  destinationValidationFailure("tmp-route-tests/destination-unsafe-source.json"),
+  /safe-for-first-prototype/,
+);
+
 assert.equal(existsSync("data/pilot-routes.json"), true);
 validateRoutes("data/pilot-routes.json");
+assert.equal(existsSync("data/pilot-destinations.json"), true);
+validateDestinations("data/pilot-destinations.json");
 
 const pilotRoutes = JSON.parse(
   await readFile("data/pilot-routes.json", "utf8"),
+);
+const pilotDestinations = JSON.parse(
+  await readFile("data/pilot-destinations.json", "utf8"),
 );
 const pilotRouteLayers = new Set(pilotRoutes.map((route) => route.route_layer));
 assert.equal(pilotRoutes.length >= 4, true);
 assert.equal(pilotRoutes.length <= 6, true);
 assert.equal(pilotRouteLayers.has("atm-background"), true);
 assert.equal(pilotRouteLayers.has("prototype-simplified"), true);
+
+const pilotDestinationTypes = new Set(
+  pilotDestinations.map((destination) => destination.destination_type),
+);
+assert.equal(pilotDestinationTypes.has("school-cluster"), true);
+assert.equal(pilotDestinationTypes.has("settlement-centre"), true);
+
+const sourceInventoryIds = new Set(
+  sourceInventory.sources.map((source) => source.id),
+);
+for (const destination of pilotDestinations) {
+  assert.equal(
+    destination.source_ids.every((sourceId) => sourceInventoryIds.has(sourceId)),
+    true,
+  );
+}
 
 const allowedDataStatuses = new Set([
   "source-context",
@@ -363,8 +482,17 @@ for (const route of pilotRoutes.filter(
 }
 const { renderRouteMap } = await import("../src/route-map.mjs");
 const renderedRouteMap = renderRouteMap(pilotRoutes);
+const renderedRouteMapWithDestinations = renderRouteMap(pilotRoutes, {
+  destinations: pilotDestinations,
+  showDestinations: true,
+});
 const renderedSelectedRouteMap = renderRouteMap(pilotRoutes, {
   selectedRouteId: "prototype-a367-utility-corridor-hypothesis",
+});
+const renderedSelectedSchoolRouteMap = renderRouteMap(pilotRoutes, {
+  destinations: pilotDestinations,
+  selectedRouteId: "prototype-somer-valley-school-access-review",
+  showDestinations: true,
 });
 assert.match(renderedRouteMap, /Original ATM-style source evidence/i);
 assert.match(renderedRouteMap, /Simplified prototype layer/i);
@@ -386,6 +514,15 @@ assert.match(renderedRouteMap, /prototype-indicative/i);
 assert.match(renderedRouteMap, /manual-prototype-sketch/i);
 assert.match(renderedRouteMap, /not a final preferred alignment/i);
 
+assert.match(renderedRouteMapWithDestinations, /School and key destination context/i);
+assert.match(renderedRouteMapWithDestinations, /data-destination-layer="pilot-destinations"/i);
+assert.match(renderedRouteMapWithDestinations, /data-destination-id="somer-valley-education-destinations"/i);
+assert.match(renderedRouteMapWithDestinations, /Somer Valley education destinations/i);
+assert.match(renderedRouteMapWithDestinations, /indicative-source-context/i);
+assert.match(renderedRouteMapWithDestinations, /no school-run impact/i);
+assert.match(renderedRouteMapWithDestinations, /data-destination-toggle/i);
+assert.match(renderedRouteMapWithDestinations, /checked/i);
+
 assert.match(renderedRouteMap, /Route data:/i);
 assert.match(renderedRouteMap, /checked-in pilot dataset/i);
 assert.match(renderedRouteMap, /B&amp;NES Active Travel Masterplan source context/i);
@@ -406,6 +543,13 @@ assert.match(renderedSelectedRouteMap, /What needs review/i);
 assert.match(renderedSelectedRouteMap, /Evidence and provenance/i);
 assert.match(renderedSelectedRouteMap, /not a final preferred alignment/i);
 assert.doesNotMatch(renderedSelectedRouteMap, /final route decision/i);
+
+assert.match(renderedSelectedSchoolRouteMap, /class="route-detail-destinations"/i);
+assert.match(renderedSelectedSchoolRouteMap, /Route-linked destination context/i);
+assert.match(renderedSelectedSchoolRouteMap, /Somer Valley education destinations/i);
+assert.match(renderedSelectedSchoolRouteMap, /High school access relevance/i);
+assert.match(renderedSelectedSchoolRouteMap, /no school-run impact/i);
+assert.doesNotMatch(renderedSelectedSchoolRouteMap, /school-run reduction/i);
 
 const pilotRoutesText = JSON.stringify(pilotRoutes);
 assert.doesNotMatch(
@@ -474,6 +618,7 @@ assert.equal(existsSync("dist/route-details.mjs"), true);
 assert.equal(existsSync("dist/app.mjs"), true);
 assert.equal(existsSync("dist/route-map.mjs"), true);
 assert.equal(existsSync("dist/data/pilot-routes.json"), true);
+assert.equal(existsSync("dist/data/pilot-destinations.json"), true);
 
 const page = await readFile("dist/index.html", "utf8");
 const visibleText = page.replace(/\s+/g, " ");
@@ -484,10 +629,13 @@ assert.match(page, /type="module" src="app\.mjs"/i);
 const clientScript = await readFile("dist/app.mjs", "utf8");
 assert.match(clientScript, /import \{ renderRouteMap \}/i);
 assert.match(clientScript, /pilot-routes\.json/i);
+assert.match(clientScript, /pilot-destinations\.json/i);
 assert.match(clientScript, /innerHTML\s*=\s*renderRouteMap/i);
 assert.match(clientScript, /addEventListener\("click"/i);
 assert.match(clientScript, /closest\("\[data-route-id\]"\)/i);
+assert.match(clientScript, /closest\("\[data-destination-toggle\]"\)/i);
 assert.match(clientScript, /selectedRouteId/i);
+assert.match(clientScript, /showDestinations/i);
 
 assert.match(
   visibleText,
@@ -512,6 +660,10 @@ assert.match(styles, /route-layer-background[\s\S]*opacity:\s*0\.[0-9]+/i);
 assert.match(styles, /route-layer-prototype[\s\S]*border-left:\s*[4-9]px/i);
 assert.match(styles, /route-line[\s\S]*cursor:\s*pointer/i);
 assert.match(styles, /route-detail-panel/i);
+assert.match(styles, /destination-layer/i);
+assert.match(styles, /destination-marker/i);
+assert.match(styles, /destination-toggle/i);
+assert.match(styles, /route-detail-destinations/i);
 assert.match(styles, /map-attribution/i);
 
 assert.equal(existsSync("README.md"), true);
@@ -525,6 +677,10 @@ assert.match(readmeText, /npm run validate:routes -- path\/to\/routes\.json/i);
 assert.match(readmeText, /data\/pilot-routes\.json/i);
 assert.match(readmeText, /pilot source inventory/i);
 assert.match(readmeText, /npm run validate:sources/i);
+assert.match(readmeText, /pilot destination dataset/i);
+assert.match(readmeText, /data\/pilot-destinations\.json/i);
+assert.match(readmeText, /npm run validate:destinations/i);
+assert.match(readmeText, /no school-run impact/i);
 
 assert.equal(existsSync(".github/workflows/pages.yml"), true);
 const workflow = await readFile(".github/workflows/pages.yml", "utf8");

--- a/scripts/validate-destinations.mjs
+++ b/scripts/validate-destinations.mjs
@@ -1,0 +1,180 @@
+import { readFile } from "node:fs/promises";
+
+const destinationPath = process.argv[2] ?? "data/pilot-destinations.json";
+const destinations = JSON.parse(await readFile(destinationPath, "utf8"));
+const sourceInventory = JSON.parse(
+  await readFile("data/pilot-source-inventory.json", "utf8"),
+);
+const sourceInventoryById = new Map(
+  Array.isArray(sourceInventory.sources)
+    ? sourceInventory.sources.map((source) => [source.id, source])
+    : [],
+);
+
+const requiredFields = [
+  "destination_id",
+  "destination_name",
+  "destination_type",
+  "pilot_area",
+  "destination_status",
+  "location_status",
+  "display_position",
+  "source_ids",
+  "related_route_ids",
+  "school_access_relevance",
+  "provenance_notes",
+  "uncertainty_notes",
+  "claim_limits",
+];
+
+const allowedDestinationTypes = [
+  "school-cluster",
+  "settlement-centre",
+  "transport-access",
+  "healthcare",
+  "employment",
+  "other-key-destination",
+];
+
+const allowedDestinationStatuses = [
+  "documented-source-context",
+  "indicative-source-context",
+  "unknown",
+];
+
+const allowedLocationStatuses = ["documented", "indicative", "unknown"];
+
+const allowedSchoolAccessRelevance = ["high", "medium", "low", "unknown"];
+
+const errors = [];
+
+function addError(message) {
+  errors.push(message);
+}
+
+function isBlank(value) {
+  return typeof value !== "string" || value.trim() === "";
+}
+
+if (!Array.isArray(destinations) || destinations.length === 0) {
+  addError("destination dataset must be a non-empty JSON array");
+} else {
+  destinations.forEach((destination, index) => {
+    if (
+      destination === null ||
+      typeof destination !== "object" ||
+      Array.isArray(destination)
+    ) {
+      addError(`destination ${index + 1}: must be an object`);
+      return;
+    }
+
+    const destinationLabel = destination.destination_id ?? `destination ${index + 1}`;
+
+    for (const field of requiredFields) {
+      if (!(field in destination)) {
+        addError(`${destinationLabel}: missing required field "${field}"`);
+      } else if (
+        field !== "display_position" &&
+        field !== "source_ids" &&
+        field !== "related_route_ids" &&
+        isBlank(destination[field])
+      ) {
+        addError(`${destinationLabel}: required field "${field}" cannot be blank`);
+      }
+    }
+
+    if (
+      "destination_type" in destination &&
+      !allowedDestinationTypes.includes(destination.destination_type)
+    ) {
+      addError(
+        `${destinationLabel}: unsupported destination_type "${destination.destination_type}"`,
+      );
+    }
+
+    if (
+      "destination_status" in destination &&
+      !allowedDestinationStatuses.includes(destination.destination_status)
+    ) {
+      addError(
+        `${destinationLabel}: unsupported destination_status "${destination.destination_status}"`,
+      );
+    }
+
+    if (
+      "location_status" in destination &&
+      !allowedLocationStatuses.includes(destination.location_status)
+    ) {
+      addError(
+        `${destinationLabel}: unsupported location_status "${destination.location_status}"`,
+      );
+    }
+
+    if (
+      "school_access_relevance" in destination &&
+      !allowedSchoolAccessRelevance.includes(destination.school_access_relevance)
+    ) {
+      addError(
+        `${destinationLabel}: unsupported school_access_relevance "${destination.school_access_relevance}"`,
+      );
+    }
+
+    if (destination.pilot_area !== "Bath to Somer Valley") {
+      addError(`${destinationLabel}: pilot_area must be "Bath to Somer Valley"`);
+    }
+
+    if (
+      !Array.isArray(destination.source_ids) ||
+      destination.source_ids.length === 0 ||
+      destination.source_ids.some(isBlank)
+    ) {
+      addError(`${destinationLabel}: source_ids must list documented sources`);
+    } else {
+      for (const sourceId of destination.source_ids) {
+        const source = sourceInventoryById.get(sourceId);
+        if (!source) {
+          addError(`${destinationLabel}: source_id "${sourceId}" is not in the source inventory`);
+        } else if (source.mvp_dataset_safety !== "safe-for-first-prototype") {
+          addError(
+            `${destinationLabel}: source_id "${sourceId}" must be safe-for-first-prototype`,
+          );
+        }
+      }
+    }
+
+    if (
+      !Array.isArray(destination.related_route_ids) ||
+      destination.related_route_ids.some(isBlank)
+    ) {
+      addError(`${destinationLabel}: related_route_ids must be an array`);
+    }
+
+    if (
+      destination.display_position === null ||
+      typeof destination.display_position !== "object" ||
+      Array.isArray(destination.display_position) ||
+      typeof destination.display_position.x !== "number" ||
+      typeof destination.display_position.y !== "number"
+    ) {
+      addError(`${destinationLabel}: display_position must include numeric x and y`);
+    }
+
+    const claimLimits = String(destination.claim_limits ?? "").toLowerCase();
+    for (const bannedClaim of [
+      "no school-run impact",
+      "no catchment coverage",
+      "no route preference",
+      "no quantified modal-shift claims",
+    ]) {
+      if (!claimLimits.includes(bannedClaim)) {
+        addError(`${destinationLabel}: claim_limits must include ${bannedClaim}`);
+      }
+    }
+  });
+}
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}

--- a/src/app.mjs
+++ b/src/app.mjs
@@ -1,18 +1,35 @@
 import { renderRouteMap } from "./route-map.mjs";
 
 const routeDatasetUrl = "data/pilot-routes.json";
+const destinationDatasetUrl = "data/pilot-destinations.json";
 const routeMap = document.querySelector("#route-map");
 
 if (routeMap) {
-  const response = await fetch(routeDatasetUrl);
-  const routes = await response.json();
+  const [routeResponse, destinationResponse] = await Promise.all([
+    fetch(routeDatasetUrl),
+    fetch(destinationDatasetUrl),
+  ]);
+  const routes = await routeResponse.json();
+  const destinations = await destinationResponse.json();
   let selectedRouteId = null;
+  let showDestinations = true;
 
   function renderSelectedRouteMap() {
-    routeMap.innerHTML = renderRouteMap(routes, { selectedRouteId });
+    routeMap.innerHTML = renderRouteMap(routes, {
+      destinations,
+      selectedRouteId,
+      showDestinations,
+    });
   }
 
   routeMap.addEventListener("click", (event) => {
+    const destinationToggle = event.target.closest("[data-destination-toggle]");
+    if (destinationToggle) {
+      showDestinations = destinationToggle.checked;
+      renderSelectedRouteMap();
+      return;
+    }
+
     const routeControl = event.target.closest("[data-route-id]");
     if (!routeControl) {
       return;

--- a/src/route-map.mjs
+++ b/src/route-map.mjs
@@ -2,6 +2,10 @@ import { formatRouteDetail } from "./route-details.mjs";
 import { styleRouteForMap } from "./route-styles.mjs";
 
 export function renderRouteMap(routes, options = {}) {
+  const destinations = Array.isArray(options.destinations)
+    ? options.destinations
+    : [];
+  const showDestinations = options.showDestinations !== false;
   const backgroundRoutes = routes.filter(
     (route) => route.route_layer === "atm-background",
   );
@@ -22,7 +26,8 @@ export function renderRouteMap(routes, options = {}) {
     "<h2>Simplified prototype layer</h2>",
     ...prototypeRoutes.map((route) => renderRoute(route, selectedRoute)),
     "</div>",
-    renderRouteDetail(selectedRoute),
+    renderDestinationLayer(destinations, { showDestinations }),
+    renderRouteDetail(selectedRoute, destinations),
     "<footer class=\"map-attribution\">Route data: checked-in pilot dataset. B&amp;NES Active Travel Masterplan source context retained as background evidence.</footer>",
     "</section>",
   ].join("");
@@ -59,7 +64,64 @@ function renderRoute(route, selectedRoute) {
   ].join("");
 }
 
-function renderRouteDetail(route) {
+function renderDestinationLayer(destinations, options) {
+  if (destinations.length === 0) {
+    return "";
+  }
+
+  return [
+    "<div class=\"destination-layer\" data-destination-layer=\"pilot-destinations\">",
+    "<label class=\"destination-toggle\">",
+    "<input type=\"checkbox\" data-destination-toggle",
+    options.showDestinations ? " checked" : "",
+    ">",
+    "<span>School and key destination context</span>",
+    "</label>",
+    options.showDestinations
+      ? [
+          "<div class=\"destination-marker-list\">",
+          ...destinations.map(renderDestination),
+          "</div>",
+        ].join("")
+      : "",
+    "</div>",
+  ].join("");
+}
+
+function renderDestination(destination) {
+  return [
+    "<article class=\"destination-marker\" data-destination-id=\"",
+    escapeHtml(destination.destination_id),
+    "\" style=\"--destination-x:",
+    escapeHtml(destination.display_position?.x ?? 0),
+    "%;--destination-y:",
+    escapeHtml(destination.display_position?.y ?? 0),
+    "%;\">",
+    "<p class=\"destination-marker-type\">",
+    escapeHtml(destination.destination_type),
+    "</p>",
+    "<h3>",
+    escapeHtml(destination.destination_name),
+    "</h3>",
+    "<p>",
+    escapeHtml(destination.destination_status),
+    " / ",
+    escapeHtml(destination.location_status),
+    "</p>",
+    "<p>",
+    escapeHtml(destination.provenance_notes),
+    "</p>",
+    "<p>",
+    escapeHtml(destination.uncertainty_notes),
+    "</p>",
+    "<p>",
+    escapeHtml(destination.claim_limits),
+    "</p>",
+    "</article>",
+  ].join("");
+}
+
+function renderRouteDetail(route, destinations = []) {
   if (!route) {
     return [
       "<aside class=\"route-detail-panel route-detail-empty\" id=\"route-detail\" aria-label=\"Route detail panel\">",
@@ -70,6 +132,9 @@ function renderRouteDetail(route) {
   }
 
   const detail = formatRouteDetail(route);
+  const linkedDestinations = destinations.filter((destination) =>
+    destination.related_route_ids?.includes(route.route_id),
+  );
   const summaryRows = [
     ["Proposed network status", detail.summary.networkStatus],
     ["Network role", detail.summary.networkRole],
@@ -107,7 +172,51 @@ function renderRouteDetail(route) {
     "<ul>",
     ...detail.notes.map((note) => `<li>${escapeHtml(note)}</li>`),
     "</ul>",
+    renderLinkedDestinations(linkedDestinations),
     "</aside>",
+  ].join("");
+}
+
+const schoolAccessLabels = {
+  high: "High school access relevance",
+  medium: "Medium school access relevance",
+  low: "Low school access relevance",
+  unknown: "Unknown school access relevance",
+};
+
+function renderLinkedDestinations(destinations) {
+  if (destinations.length === 0) {
+    return "";
+  }
+
+  return [
+    "<section class=\"route-detail-destinations\">",
+    "<h3>Route-linked destination context</h3>",
+    "<ul>",
+    ...destinations.map(renderLinkedDestination),
+    "</ul>",
+    "</section>",
+  ].join("");
+}
+
+function renderLinkedDestination(destination) {
+  return [
+    "<li>",
+    "<strong>",
+    escapeHtml(destination.destination_name),
+    "</strong>",
+    " - ",
+    escapeHtml(
+      schoolAccessLabels[destination.school_access_relevance] ??
+        "Unknown school access relevance",
+    ),
+    ". ",
+    escapeHtml(destination.provenance_notes),
+    " ",
+    escapeHtml(destination.uncertainty_notes),
+    " ",
+    escapeHtml(destination.claim_limits),
+    "</li>",
   ].join("");
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -272,6 +272,69 @@ h3 {
   box-shadow: 0 8px 18px rgba(0, 114, 178, 0.12);
 }
 
+.destination-layer {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid #cdded4;
+  border-radius: 8px;
+  background: #f7fbf7;
+}
+
+.destination-toggle {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  color: #1d5f45;
+  font-weight: 800;
+}
+
+.destination-toggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: #1d7f5d;
+}
+
+.destination-marker-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.destination-marker {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid #cfe3d8;
+  border-left: 5px solid #1d7f5d;
+  border-radius: 8px;
+  background: #ffffff;
+  text-align: left;
+}
+
+.destination-marker h3,
+.destination-marker p {
+  max-width: none;
+  margin: 0;
+}
+
+.destination-marker h3 {
+  font-size: 0.95rem;
+  line-height: 1.3;
+}
+
+.destination-marker p {
+  color: #425466;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.destination-marker-type {
+  color: #1d5f45;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
 .route-detail-panel {
   display: grid;
   gap: 12px;
@@ -336,6 +399,17 @@ h3 {
 
 .route-detail-empty {
   color: #52616f;
+}
+
+.route-detail-destinations {
+  display: grid;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid #cdded4;
+}
+
+.route-detail-destinations strong {
+  color: #1d5f45;
 }
 
 .map-attribution {


### PR DESCRIPTION
## Summary
- Add an MVP-safe pilot destination dataset for school and settlement-centre context.
- Add destination validation for provenance, uncertainty, source safety, and no-overclaim guardrails.
- Render a toggleable destination layer and linked route-detail destination context.

## Test Plan
- [x] npm test
- [x] npm run validate:destinations
- [x] npm run validate:sources
- [x] npm run build

Closes #9