### PR TITLE
Add prototype smoke accessibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,19 @@ evidence has been added.
 
 ```sh
 npm test
+npm run test:smoke
 npm run build
 npm run validate:sources
 npm run validate:destinations
 ```
 
 The build output is written to `dist/`.
+
+`npm run test:smoke` builds the static site, loads the generated `dist/`
+assets through a local static-asset harness, verifies the MVP loads, checks the
+caveat, route rendering, route-detail selection, legend wording, narrow/mobile
+CSS coverage, and runs focused accessibility assertions over the rendered
+prototype surface.
 
 ## Route Data Contract
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "node scripts/build.mjs",
-    "test": "node scripts/test.mjs",
+    "test": "node scripts/test.mjs && node scripts/smoke-test.mjs",
+    "test:smoke": "node scripts/smoke-test.mjs",
     "validate:routes": "node scripts/validate-routes.mjs",
     "validate:sources": "node scripts/validate-source-inventory.mjs",
     "validate:destinations": "node scripts/validate-destinations.mjs"

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize, resolve, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const distDirectory = resolve("dist");
+const baseUrl = "http://atm-prioritisation.local/";
+
+execFileSync("npm", ["run", "build"], { stdio: "pipe" });
+
+const pageResponse = await fetchBuiltAsset("/");
+assert.equal(pageResponse.status, 200);
+
+const pageHtml = await pageResponse.text();
+const pageText = visibleText(pageHtml);
+assert.match(
+  pageText,
+  /independent personal proof-of-concept work, not a council-owned plan, WECA-owned plan, formal LCWIP, or final prioritised network/i,
+);
+assert.match(pageText, /Route status/i);
+assert.match(pageText, /Route status uses colour and line pattern/i);
+assert.match(pageText, /Modal shift potential/i);
+assert.match(pageText, /line width; wider lines indicate stronger potential/i);
+
+const cssResponse = await fetchBuiltAsset("styles.css");
+assert.equal(cssResponse.status, 200);
+const css = await cssResponse.text();
+assert.match(css, /@media\s*\(max-width:\s*780px\)/i);
+assert.match(css, /grid-template-columns:\s*1fr/i);
+
+const routeMap = await renderAppWithHarness();
+assert.match(routeMap.innerHTML, /data-route-id="/i);
+assert.match(routeMap.innerHTML, /Original ATM-style source evidence/i);
+assert.match(routeMap.innerHTML, /Simplified prototype layer/i);
+
+const selectedRouteId = firstRouteId(routeMap.innerHTML);
+routeMap.dispatchClick(routeTarget(selectedRouteId));
+
+assert.match(routeMap.innerHTML, /id="route-detail"/i);
+assert.match(routeMap.innerHTML, /Route detail/i);
+assert.match(routeMap.innerHTML, /Why this route matters/i);
+assert.match(routeMap.innerHTML, /What needs review/i);
+assert.match(routeMap.innerHTML, /Evidence and provenance/i);
+
+auditAccessibility(`${pageHtml}\n${routeMap.innerHTML}`);
+
+async function fetchBuiltAsset(resource) {
+  try {
+    const assetUrl = new URL(String(resource), baseUrl);
+    const requestedPath =
+      assetUrl.pathname === "/" ? "/index.html" : assetUrl.pathname;
+    const filePath = safeJoin(distDirectory, decodeURIComponent(requestedPath));
+    const file = await readFile(filePath);
+
+    return new Response(file, {
+      status: 200,
+      headers: {
+        "content-type": contentType(filePath),
+      },
+    });
+  } catch {
+    return new Response("Not found", {
+      status: 404,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+      },
+    });
+  }
+}
+
+function safeJoin(rootDirectory, pathname) {
+  const normalizedPath = normalize(pathname).replace(/^(\.\.[/\\])+/, "");
+  const filePath = resolve(join(rootDirectory, normalizedPath));
+
+  if (filePath !== rootDirectory && !filePath.startsWith(`${rootDirectory}${sep}`)) {
+    throw new Error(`Refusing to serve path outside dist: ${pathname}`);
+  }
+
+  return filePath;
+}
+
+function contentType(filePath) {
+  const extension = extname(filePath);
+  if (extension === ".html") return "text/html; charset=utf-8";
+  if (extension === ".css") return "text/css; charset=utf-8";
+  if (extension === ".mjs" || extension === ".js") {
+    return "text/javascript; charset=utf-8";
+  }
+  if (extension === ".json") return "application/json; charset=utf-8";
+
+  return "application/octet-stream";
+}
+
+async function renderAppWithHarness() {
+  const routeMap = createRouteMapElement();
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.document = {
+    querySelector(selector) {
+      return selector === "#route-map" ? routeMap : null;
+    },
+  };
+  globalThis.fetch = (resource, options) => {
+    assert.equal(options, undefined);
+    return fetchBuiltAsset(resource);
+  };
+
+  try {
+    await import(`${pathToFileURL(resolve("dist/app.mjs")).href}?smoke=${Date.now()}`);
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.fetch = originalFetch;
+  }
+
+  return routeMap;
+}
+
+function createRouteMapElement() {
+  const listeners = new Map();
+
+  return {
+    innerHTML: "",
+    addEventListener(type, listener) {
+      listeners.set(type, listener);
+    },
+    dispatchClick(target) {
+      const listener = listeners.get("click");
+      assert.equal(typeof listener, "function");
+      listener({ target });
+    },
+  };
+}
+
+function routeTarget(routeId) {
+  return {
+    closest(selector) {
+      if (selector === "[data-destination-toggle]") {
+        return null;
+      }
+
+      if (selector === "[data-route-id]") {
+        return {
+          dataset: {
+            routeId,
+          },
+        };
+      }
+
+      return null;
+    },
+  };
+}
+
+function firstRouteId(html) {
+  const match = html.match(/data-route-id="([^"]+)"/i);
+  assert.notEqual(match, null);
+  return match[1];
+}
+
+function auditAccessibility(html) {
+  assert.match(html, /<html[^>]+lang="en"/i);
+  assert.match(html, /<title>[^<]+<\/title>/i);
+  assert.match(html, /<main\b/i);
+  assert.doesNotMatch(html, /<img\b(?![^>]*\balt=)/i);
+
+  const labelledRegions = html.match(/<(section|aside)\b[^>]*aria-label="[^"]+"/gi);
+  assert.ok((labelledRegions?.length ?? 0) >= 3);
+
+  const routeButtons = html.match(/<button\b[^>]*class="route-line"[\s\S]*?<\/button>/gi);
+  assert.ok((routeButtons?.length ?? 0) > 0);
+
+  for (const button of routeButtons) {
+    assert.match(button, /aria-controls="route-detail"/i);
+    assert.match(button, /aria-pressed="(true|false)"/i);
+    assert.match(visibleText(button), /\S/);
+  }
+
+  const controlledIds = [
+    ...html.matchAll(/aria-controls="([^"]+)"/gi),
+  ].map((match) => match[1]);
+
+  for (const controlledId of controlledIds) {
+    assert.match(html, new RegExp(`id="${escapeRegExp(controlledId)}"`, "i"));
+  }
+
+  const labelledCheckboxes = html.match(
+    /<label\b[\s\S]*<input\b[^>]*type="checkbox"[\s\S]*<\/label>/gi,
+  );
+  assert.ok((labelledCheckboxes?.length ?? 0) >= 1);
+  assert.ok(labelledCheckboxes.some((label) => /School and key destination context/i.test(label)));
+}
+
+function visibleText(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- Adds `npm run test:smoke` for generated static-site smoke coverage.
- Exercises MVP load, caveat visibility, route rendering, route-detail selection, legend wording, mobile CSS coverage, and focused accessibility assertions.
- Documents the smoke test command and includes it in `npm test`.

## Test Plan
- [x] `npm test`

Closes #10