### PR TITLE
Extract Bath to Somer Valley ATM geometry

### DIFF
--- a/data/atm-routes-bath-somer-valley.geojson
+++ b/data/atm-routes-bath-somer-valley.geojson
@@ -1,0 +1,204 @@
+{
+  "type": "FeatureCollection",
+  "name": "Bath to Somer Valley extracted ATM source geometry",
+  "metadata": {
+    "batch_id": "bath-somer-valley",
+    "geometry_precision": "review-map",
+    "geometry_status": "best-fit-extracted-from-public-atm-map",
+    "official_geometry": false,
+    "notes": "Best-fit indicative source/context geometry extracted from public ATM map and document context for prototype review. This is not official reusable council GeoJSON or engineering/legal alignment."
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-2.448, 51.293],
+          [-2.439, 51.301],
+          [-2.431, 51.31],
+          [-2.426, 51.316]
+        ]
+      },
+      "properties": {
+        "atm_route_id": "atm-5-6A-a367-bristol-road-strategic",
+        "route_name": "A367 / Bristol Road strategic route",
+        "source_layer": "atm-route",
+        "source_atm_classification": "strategic",
+        "geometry_status": "best-fit-extracted-from-public-atm-map",
+        "geometry_confidence": "medium",
+        "needs_human_spot_check": true,
+        "source_ids": [
+          "banes-active-travel-masterplan-documents",
+          "banes-active-travel-masterplan-route-map"
+        ],
+        "provenance_notes": "Derived from the public ATM route-map PDF and Part 6 route table text describing route 5-6 as A367/Bristol Road strategic route between Radstock and Peasedown St John.",
+        "uncertainty_notes": "Best-fit follows the visible A367/Bristol Road corridor at review-map precision. It is not official geometry, does not settle exact alignment, and should be spot-checked against the source map."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-2.448, 51.293],
+          [-2.441, 51.302],
+          [-2.435, 51.311],
+          [-2.426, 51.316]
+        ]
+      },
+      "properties": {
+        "atm_route_id": "atm-5-6a-bath-old-road-quiet",
+        "route_name": "Bath Old Road quiet route alternative",
+        "source_layer": "atm-route",
+        "source_atm_classification": "quiet",
+        "geometry_status": "best-fit-extracted-from-public-atm-map",
+        "geometry_confidence": "low",
+        "needs_human_spot_check": true,
+        "source_ids": [
+          "banes-active-travel-masterplan-documents",
+          "banes-active-travel-masterplan-route-map"
+        ],
+        "provenance_notes": "Derived from the public ATM route-map PDF and Part 6 route table text describing route 5-6a as the nearby quiet route along Bath Old Road to avoid the steep hill out of Radstock.",
+        "uncertainty_notes": "The source text identifies the quiet alternative but the public map graphic is dense in this area. Alignment is best-fit and low-confidence until visually checked."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-2.426, 51.316],
+          [-2.403, 51.334],
+          [-2.383, 51.354],
+          [-2.371, 51.369]
+        ]
+      },
+      "properties": {
+        "atm_route_id": "atm-6-8A-peasedown-bath-strategic",
+        "route_name": "Peasedown St John to Bath strategic route",
+        "source_layer": "atm-route",
+        "source_atm_classification": "strategic",
+        "geometry_status": "best-fit-extracted-from-public-atm-map",
+        "geometry_confidence": "medium",
+        "needs_human_spot_check": true,
+        "source_ids": [
+          "banes-active-travel-masterplan-documents",
+          "banes-active-travel-masterplan-route-map"
+        ],
+        "provenance_notes": "Derived from the public ATM route-map PDF and Part 6 route table text describing route 6-8A as continuing from Peasedown St John into Bath, with the SVL text noting the A367 approach along Wellsway to the A36 Churchill gyratory.",
+        "uncertainty_notes": "Best-fit follows the broad Peasedown to Bath/Wellsway corridor. It is not official route geometry and does not settle junction or carriageway-side detail."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-2.448, 51.293],
+          [-2.473, 51.287],
+          [-2.485, 51.285],
+          [-2.529, 51.298]
+        ]
+      },
+      "properties": {
+        "atm_route_id": "atm-5-3A-a362-radstock-midsomer-farrington",
+        "route_name": "A362 strategic route from Radstock to Midsomer Norton and Farrington Gurney",
+        "source_layer": "atm-route",
+        "source_atm_classification": "strategic",
+        "geometry_status": "best-fit-extracted-from-public-atm-map",
+        "geometry_confidence": "medium",
+        "needs_human_spot_check": true,
+        "source_ids": [
+          "banes-active-travel-masterplan-documents",
+          "banes-active-travel-masterplan-route-map"
+        ],
+        "provenance_notes": "Derived from the public ATM route-map PDF and Part 6 route table text describing route 5-3A as a new strategic route proposal on the A362 providing direct access for cyclists.",
+        "uncertainty_notes": "Best-fit follows the Radstock, Midsomer Norton and Farrington Gurney corridor at review-map precision. Exact scheme limits remain unresolved."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-2.485, 51.285],
+          [-2.501, 51.305],
+          [-2.515, 51.314],
+          [-2.535, 51.322]
+        ]
+      },
+      "properties": {
+        "atm_route_id": "atm-3-4b-old-mills-lane-quiet",
+        "route_name": "Old Mills Lane quiet route",
+        "source_layer": "atm-route",
+        "source_atm_classification": "quiet",
+        "geometry_status": "best-fit-extracted-from-public-atm-map",
+        "geometry_confidence": "medium",
+        "needs_human_spot_check": true,
+        "source_ids": [
+          "banes-active-travel-masterplan-documents",
+          "banes-active-travel-masterplan-route-map"
+        ],
+        "provenance_notes": "Derived from the public ATM route-map PDF and Part 6 text describing a proposed quiet route on Old Mills Lane, accessible from the A362 strategic route.",
+        "uncertainty_notes": "Best-fit uses the Old Mills/Paulton/Hallatrow corridor for review. It should be checked against the source map before any public-facing precision is implied."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-2.359, 51.381],
+          [-2.336, 51.359],
+          [-2.345, 51.327],
+          [-2.448, 51.293],
+          [-2.485, 51.285]
+        ]
+      },
+      "properties": {
+        "atm_route_id": "context-ncn24-two-tunnels-colliers-way",
+        "route_name": "NCN 24 / Two Tunnels / Colliers Way context",
+        "source_layer": "context-greenway",
+        "source_atm_classification": "context",
+        "geometry_status": "best-fit-extracted-from-public-atm-map",
+        "geometry_confidence": "medium",
+        "needs_human_spot_check": true,
+        "source_ids": [
+          "banes-active-travel-masterplan-documents",
+          "banes-active-travel-masterplan-route-map",
+          "walk-wheel-cycle-trust-ncn-public"
+        ],
+        "provenance_notes": "Derived from public ATM Part 6 existing infrastructure text describing NCN Route 24 from Bath through Radstock, Colliers Way, and NCN 244 / Two Tunnels Greenway connections.",
+        "uncertainty_notes": "Included as greenway context for comparison with ATM/prototype corridors. It is not a prototype prioritisation decision and should not be treated as official extracted NCN geometry."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [-2.485, 51.285],
+          [-2.471, 51.287],
+          [-2.456, 51.286],
+          [-2.448, 51.293]
+        ]
+      },
+      "properties": {
+        "atm_route_id": "context-norton-radstock-greenway-five-arches",
+        "route_name": "Norton-Radstock and Five Arches greenway context",
+        "source_layer": "context-greenway",
+        "source_atm_classification": "context",
+        "geometry_status": "best-fit-extracted-from-public-atm-map",
+        "geometry_confidence": "medium",
+        "needs_human_spot_check": true,
+        "source_ids": [
+          "banes-active-travel-masterplan-documents",
+          "banes-active-travel-masterplan-route-map"
+        ],
+        "provenance_notes": "Derived from public ATM Part 6 existing infrastructure text describing the Norton-Radstock Greenway from Northmead Road in Midsomer Norton to Somervale Road in Radstock, plus Five Arches Greenway context.",
+        "uncertainty_notes": "Best-fit greenway context only. Exact trail alignment and legal status are not established by this dataset."
+      }
+    }
+  ]
+}

--- a/data/pilot-source-inventory.json
+++ b/data/pilot-source-inventory.json
@@ -36,6 +36,19 @@
       "claim_limits": "official context only; not route preference; no formal funding eligibility or route deliverability claims"
     },
     {
+      "id": "banes-active-travel-masterplan-route-map",
+      "title": "Active Travel Masterplan Route Map appendix",
+      "publisher": "Bath and North East Somerset Council",
+      "url": "https://democracy.bathnes.gov.uk/documents/s85703/E3594%20-%20Appendix%20B%20-%20Active%20Travel%20Masterplan%20Route%20Map.pdf",
+      "category": "atm-route-evidence",
+      "evidence_strength": "official-source-evidence",
+      "mvp_dataset_safety": "review-before-use",
+      "what_it_would_be_used_for": "Provide public ATM network-map graphics for best-fit extraction when reusable route GeoJSON is unavailable.",
+      "provenance_guidance": "Record page, visible route classification, extraction date, and whether the line was best-fit traced from the public map graphic.",
+      "uncertainty_guidance": "Use as official source context for visible route intent only; extracted coordinates are best-fit indicative geometry, not official reusable council GeoJSON.",
+      "claim_limits": "public map graphic context only; not official reusable geometry; no route preference, deliverability, or engineering alignment claims"
+    },
+    {
       "id": "banes-planned-active-travel-routes",
       "title": "View and comment on planned Active Travel routes",
       "publisher": "Bath and North East Somerset Council",

--- a/docs/product/bath-somer-valley-atm-extraction.md
+++ b/docs/product/bath-somer-valley-atm-extraction.md
@@ -1,0 +1,50 @@
+# Bath to Somer Valley ATM extraction
+
+Extraction date: 2026-05-03
+
+## Scope
+
+This batch extracts review-map precision source/context geometry for the Bath to Somer Valley area. It is intended to unblock the first Leaflet prototype map, not to produce official engineering or legal route alignments.
+
+The extracted dataset is `data/atm-routes-bath-somer-valley.geojson`.
+
+## Public sources used
+
+- `Active Travel Masterplan - Appendix B - Active Travel Masterplan Route Map`, public route-map PDF from the 13 February 2025 Cabinet papers.
+- `Active Travel Masterplan Feb 2025 - Part 6 of 7`, public B&NES document page download, especially section 8.1 existing infrastructure and route table entries for the Somer Valley / Bath corridor.
+- `data/pilot-source-inventory.json`, for existing project source IDs and claim limits.
+
+## Method
+
+- The public ATM route-map graphic was used as the visual route source.
+- The Part 6 route table and infrastructure text were used to identify route IDs, route descriptions, and source/context distinctions.
+- Coordinates were drafted as best-fit lon/lat lines against public map context at review-map precision.
+- Lines follow recognisable corridors where the source text names them, such as A367 / Bristol Road, Peasedown St John to Bath, A362, Old Mills Lane, NCN 24 / Two Tunnels / Colliers Way, and Norton-Radstock / Five Arches Greenway context.
+- The output is not official reusable council GeoJSON and must not be treated as exact design, legal, or delivery alignment.
+
+## Extracted features
+
+- `atm-5-6A-a367-bristol-road-strategic`
+- `atm-5-6a-bath-old-road-quiet`
+- `atm-6-8A-peasedown-bath-strategic`
+- `atm-5-3A-a362-radstock-midsomer-farrington`
+- `atm-3-4b-old-mills-lane-quiet`
+- `context-ncn24-two-tunnels-colliers-way`
+- `context-norton-radstock-greenway-five-arches`
+
+## Ambiguities and spot checks
+
+- The public route-map graphic is dense around Radstock, Midsomer Norton, and Peasedown St John, so all features are marked for human spot-check before relying on them for external interpretation.
+- `atm-5-6a-bath-old-road-quiet` is low-confidence because the source text identifies the quiet alternative, but the exact visible map line is difficult to distinguish in the dense corridor.
+- Greenway context features are included to preserve comparison context. They are not prototype prioritisation decisions and are not official extracted NCN geometry.
+- The A367 prototype hypothesis is intentionally excluded from this extracted ATM source dataset unless a matching source route is visible in the public ATM material.
+
+## Validation
+
+Run:
+
+```sh
+npm run validate:atm-routes -- data/atm-routes-bath-somer-valley.geojson
+```
+
+Validation checks GeoJSON shape, lon/lat coordinate bounds, required provenance properties, geometry confidence, low-confidence spot-check flags, and caveat language.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "node scripts/test.mjs && node scripts/smoke-test.mjs",
     "test:smoke": "node scripts/smoke-test.mjs",
     "validate:routes": "node scripts/validate-routes.mjs",
+    "validate:atm-routes": "node scripts/validate-atm-routes.mjs",
     "validate:sources": "node scripts/validate-source-inventory.mjs",
     "validate:destinations": "node scripts/validate-destinations.mjs"
   }

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -82,8 +82,83 @@ assert.equal(
   "node scripts/validate-destinations.mjs",
 );
 
+assert.equal(
+  packageJson.scripts["validate:atm-routes"],
+  "node scripts/validate-atm-routes.mjs",
+);
+
 execFileSync("npm", ["run", "validate:sources"], { stdio: "pipe" });
 execFileSync("npm", ["run", "validate:destinations"], { stdio: "pipe" });
+
+function validateAtmRoutes(geoJsonFile) {
+  return execFileSync("node", ["scripts/validate-atm-routes.mjs", geoJsonFile], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function atmRoutesValidationFailure(geoJsonFile) {
+  try {
+    validateAtmRoutes(geoJsonFile);
+  } catch (error) {
+    assert.notEqual(error.status, 0);
+    return error.stderr;
+  }
+
+  assert.fail(`Expected ATM route validation to fail for ${geoJsonFile}`);
+}
+
+assert.equal(existsSync("data/atm-routes-bath-somer-valley.geojson"), true);
+validateAtmRoutes("data/atm-routes-bath-somer-valley.geojson");
+const bathSomerValleyAtmRoutes = JSON.parse(
+  await readFile("data/atm-routes-bath-somer-valley.geojson", "utf8"),
+);
+assert.equal(bathSomerValleyAtmRoutes.type, "FeatureCollection");
+assert.equal(bathSomerValleyAtmRoutes.features.length >= 5, true);
+assert.equal(
+  bathSomerValleyAtmRoutes.features.some(
+    (feature) => feature.properties?.source_layer === "atm-route",
+  ),
+  true,
+);
+assert.equal(
+  bathSomerValleyAtmRoutes.features.some(
+    (feature) => feature.properties?.source_layer === "context-greenway",
+  ),
+  true,
+);
+assert.equal(
+  bathSomerValleyAtmRoutes.features.some(
+    (feature) => feature.properties?.source_layer === "prototype-hypothesis",
+  ),
+  false,
+);
+const knownSourceIds = new Set(
+  sourceInventory.sources.map((source) => source.id),
+);
+for (const feature of bathSomerValleyAtmRoutes.features) {
+  assert.equal(
+    feature.properties.source_ids.every((sourceId) =>
+      knownSourceIds.has(sourceId),
+    ),
+    true,
+  );
+}
+assert.equal(
+  existsSync("docs/product/bath-somer-valley-atm-extraction.md"),
+  true,
+);
+const bathSomerValleyExtractionNote = await readFile(
+  "docs/product/bath-somer-valley-atm-extraction.md",
+  "utf8",
+);
+const bathSomerValleyExtractionNoteText =
+  bathSomerValleyExtractionNote.replace(/\s+/g, " ");
+assert.match(bathSomerValleyExtractionNoteText, /Bath to Somer Valley/i);
+assert.match(bathSomerValleyExtractionNoteText, /Active Travel Masterplan Route Map/i);
+assert.match(bathSomerValleyExtractionNoteText, /best-fit/i);
+assert.match(bathSomerValleyExtractionNoteText, /ambigu/i);
+assert.match(bathSomerValleyExtractionNoteText, /not official reusable council GeoJSON/i);
 
 assert.equal(sourceInventory.pilot_area, "Bath to Somer Valley");
 assert.equal(sourceInventory.review_status, "reviewed-for-mvp");
@@ -115,6 +190,42 @@ assert.equal(
 
 await rm("tmp-route-tests", { recursive: true, force: true });
 await mkdir("tmp-route-tests", { recursive: true });
+
+await writeFile("tmp-route-tests/not-feature-collection.geojson", "{}\n");
+assert.match(
+  atmRoutesValidationFailure("tmp-route-tests/not-feature-collection.geojson"),
+  /FeatureCollection/,
+);
+
+await writeFile(
+  "tmp-route-tests/atm-feature-missing-properties.geojson",
+  `${JSON.stringify(
+    {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: {
+            type: "LineString",
+            coordinates: [
+              [-2.45, 51.29],
+              [-2.42, 51.32],
+            ],
+          },
+          properties: {},
+        },
+      ],
+    },
+    null,
+    2,
+  )}\n`,
+);
+assert.match(
+  atmRoutesValidationFailure(
+    "tmp-route-tests/atm-feature-missing-properties.geojson",
+  ),
+  /atm_route_id/,
+);
 
 function validateRoutes(routeFile) {
   return execFileSync("node", ["scripts/validate-routes.mjs", routeFile], {

--- a/scripts/validate-atm-routes.mjs
+++ b/scripts/validate-atm-routes.mjs
@@ -1,0 +1,173 @@
+import { readFile } from "node:fs/promises";
+
+const [geoJsonFile] = process.argv.slice(2);
+
+if (!geoJsonFile) {
+  console.error("Usage: node scripts/validate-atm-routes.mjs <routes.geojson>");
+  process.exit(1);
+}
+
+const geoJson = JSON.parse(await readFile(geoJsonFile, "utf8"));
+const errors = [];
+const allowedGeometryTypes = new Set(["LineString", "MultiLineString"]);
+const allowedSourceLayers = new Set([
+  "atm-route",
+  "context-greenway",
+  "context-route",
+]);
+const allowedGeometryConfidence = new Set(["high", "medium", "low"]);
+const requiredProperties = [
+  "atm_route_id",
+  "route_name",
+  "source_layer",
+  "source_atm_classification",
+  "geometry_status",
+  "geometry_confidence",
+  "needs_human_spot_check",
+  "source_ids",
+  "provenance_notes",
+  "uncertainty_notes",
+];
+const officialGeometryPattern =
+  /\bofficial\s+(reusable\s+)?(council\s+)?(geojson|geometry)\b/i;
+const bounds = {
+  minLon: -2.65,
+  maxLon: -2.25,
+  minLat: 51.2,
+  maxLat: 51.45,
+};
+
+if (geoJson.type !== "FeatureCollection") {
+  errors.push("ATM route dataset must be a GeoJSON FeatureCollection.");
+}
+
+if (!Array.isArray(geoJson.features)) {
+  errors.push("ATM route dataset must include a features array.");
+}
+
+if (Array.isArray(geoJson.features)) {
+  geoJson.features.forEach((feature, featureIndex) => {
+    const featureLabel =
+      feature?.properties?.atm_route_id ?? `feature ${featureIndex + 1}`;
+
+    if (feature?.type !== "Feature") {
+      errors.push(`${featureLabel}: feature must have type "Feature"`);
+      return;
+    }
+
+    if (!allowedGeometryTypes.has(feature.geometry?.type)) {
+      errors.push(
+        `${featureLabel}: geometry must be LineString or MultiLineString`,
+      );
+    } else {
+      for (const coordinate of coordinatesFor(feature.geometry)) {
+        if (!isCoordinatePair(coordinate)) {
+          errors.push(`${featureLabel}: coordinates must be lon/lat pairs`);
+          continue;
+        }
+
+        const [lon, lat] = coordinate;
+        if (
+          lon < bounds.minLon ||
+          lon > bounds.maxLon ||
+          lat < bounds.minLat ||
+          lat > bounds.maxLat
+        ) {
+          errors.push(
+            `${featureLabel}: coordinate ${lon},${lat} is outside B&NES pilot bounds`,
+          );
+        }
+      }
+    }
+
+    const properties = feature.properties;
+    if (properties === null || typeof properties !== "object") {
+      errors.push(`${featureLabel}: properties must be an object`);
+      return;
+    }
+
+    for (const property of requiredProperties) {
+      if (!(property in properties)) {
+        errors.push(`${featureLabel}: missing required property "${property}"`);
+      } else if (
+        typeof properties[property] === "string" &&
+        properties[property].trim() === ""
+      ) {
+        errors.push(`${featureLabel}: required property "${property}" cannot be blank`);
+      }
+    }
+
+    if (
+      "source_layer" in properties &&
+      !allowedSourceLayers.has(properties.source_layer)
+    ) {
+      errors.push(
+        `${featureLabel}: unsupported source_layer "${properties.source_layer}"`,
+      );
+    }
+
+    if (
+      "geometry_status" in properties &&
+      properties.geometry_status !== "best-fit-extracted-from-public-atm-map"
+    ) {
+      errors.push(
+        `${featureLabel}: geometry_status must be "best-fit-extracted-from-public-atm-map"`,
+      );
+    }
+
+    if (
+      "geometry_confidence" in properties &&
+      !allowedGeometryConfidence.has(properties.geometry_confidence)
+    ) {
+      errors.push(
+        `${featureLabel}: unsupported geometry_confidence "${properties.geometry_confidence}"`,
+      );
+    }
+
+    if (
+      properties.geometry_confidence === "low" &&
+      properties.needs_human_spot_check !== true
+    ) {
+      errors.push(
+        `${featureLabel}: low-confidence features must set needs_human_spot_check true`,
+      );
+    }
+
+    if (!Array.isArray(properties.source_ids) || properties.source_ids.length === 0) {
+      errors.push(`${featureLabel}: source_ids must be a non-empty array`);
+    }
+
+    if (
+      impliesOfficialGeometry(properties.provenance_notes ?? "") ||
+      impliesOfficialGeometry(properties.uncertainty_notes ?? "")
+    ) {
+      errors.push(`${featureLabel}: notes must not imply official reusable geometry`);
+    }
+  });
+}
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+
+function coordinatesFor(geometry) {
+  if (geometry.type === "LineString") {
+    return geometry.coordinates ?? [];
+  }
+
+  return (geometry.coordinates ?? []).flat();
+}
+
+function isCoordinatePair(value) {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    value.every((coordinate) => typeof coordinate === "number")
+  );
+}
+
+function impliesOfficialGeometry(value) {
+  const text = String(value);
+  return officialGeometryPattern.test(text) && !/not\s+official/i.test(text);
+}


### PR DESCRIPTION
## Summary
- Add a Bath to Somer Valley extracted ATM/source GeoJSON batch with review-map precision best-fit geometry.
- Add ATM route GeoJSON validation and source inventory coverage for the public route-map appendix.
- Document extraction sources, method, ambiguities, and caveats.

## Test Plan
- [x] npm test
- [x] npm run validate:atm-routes -- data/atm-routes-bath-somer-valley.geojson
- [x] git diff --check

Closes #21