### PR TITLE
Add Leaflet ATM map and extraction scaffold

### DIFF
--- a/data/atm-route-extraction-schema.json
+++ b/data/atm-route-extraction-schema.json
@@ -1,0 +1,75 @@
+{
+  "schema_name": "B&NES ATM route extraction schema",
+  "schema_version": "0.1.0",
+  "dataset_type": "GeoJSON FeatureCollection",
+  "required_collection_metadata": [
+    "batch_id",
+    "batch_name",
+    "batch_area",
+    "extraction_status",
+    "geometry_precision",
+    "geometry_status",
+    "official_geometry",
+    "source_summary",
+    "notes"
+  ],
+  "allowed_collection_values": {
+    "extraction_status": [
+      "pilot-batch",
+      "planned-batch",
+      "in-progress",
+      "complete",
+      "blocked"
+    ],
+    "geometry_precision": [
+      "review-map",
+      "batch-plan",
+      "unextractable"
+    ],
+    "geometry_status": [
+      "best-fit-extracted-from-public-atm-map",
+      "not-yet-extracted",
+      "ambiguous-or-unextractable"
+    ]
+  },
+  "required_feature_properties": [
+    "atm_route_id",
+    "route_name",
+    "source_layer",
+    "source_atm_classification",
+    "geometry_status",
+    "geometry_confidence",
+    "needs_human_spot_check",
+    "source_ids",
+    "provenance_notes",
+    "uncertainty_notes"
+  ],
+  "allowed_feature_values": {
+    "source_layer": [
+      "atm-route",
+      "context-greenway",
+      "context-route"
+    ],
+    "geometry_confidence": [
+      "high",
+      "medium",
+      "low",
+      "unextractable"
+    ],
+    "geometry_status": [
+      "best-fit-extracted-from-public-atm-map",
+      "ambiguous-or-unextractable"
+    ]
+  },
+  "batching_expectations": {
+    "unit": "geographic batch",
+    "future_batches": [
+      "bath-core",
+      "bath-north-east",
+      "keynsham-and-saltford",
+      "somer-valley",
+      "rural-connections"
+    ],
+    "rule": "Extract future B&NES areas in reviewable geographic batches; record ambiguous or unextractable features rather than guessing alignments."
+  }
+}

--- a/data/atm-routes-bath-somer-valley.geojson
+++ b/data/atm-routes-bath-somer-valley.geojson
@@ -3,9 +3,13 @@
   "name": "Bath to Somer Valley extracted ATM source geometry",
   "metadata": {
     "batch_id": "bath-somer-valley",
+    "batch_name": "Bath to Somer Valley pilot batch",
+    "batch_area": "Bath to Somer Valley",
+    "extraction_status": "pilot-batch",
     "geometry_precision": "review-map",
     "geometry_status": "best-fit-extracted-from-public-atm-map",
     "official_geometry": false,
+    "source_summary": "Public B&NES Active Travel Masterplan route-map context and related document text.",
     "notes": "Best-fit indicative source/context geometry extracted from public ATM map and document context for prototype review. This is not official reusable council GeoJSON or engineering/legal alignment."
   },
   "features": [

--- a/docs/product/full-banes-atm-extraction-plan.md
+++ b/docs/product/full-banes-atm-extraction-plan.md
@@ -1,0 +1,51 @@
+# Full B&NES ATM route extraction plan
+
+## Purpose
+
+Issue #20 should prepare the full B&NES ATM route extraction without trying to complete every geography in one change. The parent dataset remains a GeoJSON FeatureCollection, and every batch must validate against `data/atm-route-extraction-schema.json` before it is used by the prototype.
+
+## Dataset contract
+
+Each geographic batch is a standalone GeoJSON FeatureCollection with collection-level `metadata` and per-feature properties. The metadata records the batch identity, area, extraction status, geometry precision, whether the geometry is official, source summary, and caveats.
+
+Every route or context feature must include:
+
+- `source_layer`
+- `source_atm_classification`
+- `geometry_status`
+- `geometry_confidence`
+- `needs_human_spot_check`
+- `source_ids`
+- `provenance_notes`
+- `uncertainty_notes`
+
+The extraction is not official reusable council GeoJSON. Public map context can support best-fit review geometry, but not engineering/legal alignment.
+
+## Batch plan
+
+Use geographic batch slices so each future PR is reviewable:
+
+- Bath to Somer Valley: existing pilot batch.
+- Bath core: central Bath ATM routes and dense junction context.
+- Bath north and east: Larkhall, Batheaston, Bathampton, and eastern links.
+- Keynsham and Saltford: routes around Keynsham, Saltford, and Bristol-facing links.
+- Somer Valley: Radstock, Midsomer Norton, Paulton, and surrounding route context beyond the pilot slice.
+- Rural connections: remaining villages, inter-settlement links, and cross-boundary context.
+
+Future batches may split these further when the public map is too dense for a single reviewable PR.
+
+## Ambiguity handling
+
+Ambiguous or unextractable features must be recorded rather than guessed. Use `geometry_status: "ambiguous-or-unextractable"` and `geometry_confidence: "unextractable"` when the source map or documents identify a route but the visible alignment is not safe to draw. Keep `needs_human_spot_check` set to `true`, preserve source IDs, and explain the uncertainty in `uncertainty_notes`.
+
+## Validation expectations
+
+Before a batch is merged:
+
+- Run `npm run validate:atm-routes -- data/<batch>.geojson`.
+- Confirm all `source_ids` point at reviewed source inventory records.
+- Confirm collection metadata identifies the geographic batch.
+- Confirm no notes imply official reusable council GeoJSON.
+- Confirm low-confidence or unextractable features are marked for human spot-check.
+
+Do not extract new geometries inside parent-preparation PRs. Geometry extraction belongs in later geographic batch PRs.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -10,3 +10,7 @@ await copyFile("src/app.mjs", "dist/app.mjs");
 await copyFile("src/route-map.mjs", "dist/route-map.mjs");
 await copyFile("data/pilot-routes.json", "dist/data/pilot-routes.json");
 await copyFile("data/pilot-destinations.json", "dist/data/pilot-destinations.json");
+await copyFile(
+  "data/atm-routes-bath-somer-valley.geojson",
+  "dist/data/atm-routes-bath-somer-valley.geojson",
+);

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -29,10 +29,23 @@ const css = await cssResponse.text();
 assert.match(css, /@media\s*\(max-width:\s*780px\)/i);
 assert.match(css, /grid-template-columns:\s*1fr/i);
 
+const atmGeoJsonResponse = await fetchBuiltAsset(
+  "data/atm-routes-bath-somer-valley.geojson",
+);
+assert.equal(atmGeoJsonResponse.status, 200);
+const atmGeoJson = await atmGeoJsonResponse.json();
+assert.equal(atmGeoJson.type, "FeatureCollection");
+
 const routeMap = await renderAppWithHarness();
 assert.match(routeMap.innerHTML, /data-route-id="/i);
 assert.match(routeMap.innerHTML, /Original ATM-style source evidence/i);
 assert.match(routeMap.innerHTML, /Simplified prototype layer/i);
+assert.match(routeMap.innerHTML, /data-leaflet-route-map/i);
+assert.match(routeMap.innerHTML, /data-map-layer="source-context"/i);
+assert.match(routeMap.innerHTML, /data-map-layer="prototype-prioritisation"/i);
+assert.match(routeMap.innerHTML, /OpenStreetMap/i);
+assert.match(routeMap.innerHTML, /OpenStreetMap contributors/i);
+assert.match(routeMap.innerHTML, /not official alignments/i);
 
 const selectedRouteId = firstRouteId(routeMap.innerHTML);
 routeMap.dispatchClick(routeTarget(selectedRouteId));

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -9,6 +9,9 @@ const routeContract = JSON.parse(
 const sourceInventory = JSON.parse(
   await readFile("data/pilot-source-inventory.json", "utf8"),
 );
+const atmRouteExtractionSchema = JSON.parse(
+  await readFile("data/atm-route-extraction-schema.json", "utf8"),
+);
 const packageJson = JSON.parse(await readFile("package.json", "utf8"));
 const { styleRouteForMap } = await import("../src/route-styles.mjs");
 const { formatRouteDetail } = await import("../src/route-details.mjs");
@@ -87,6 +90,38 @@ assert.equal(
   "node scripts/validate-atm-routes.mjs",
 );
 
+assert.deepEqual(atmRouteExtractionSchema.required_collection_metadata, [
+  "batch_id",
+  "batch_name",
+  "batch_area",
+  "extraction_status",
+  "geometry_precision",
+  "geometry_status",
+  "official_geometry",
+  "source_summary",
+  "notes",
+]);
+
+assert.deepEqual(atmRouteExtractionSchema.required_feature_properties, [
+  "atm_route_id",
+  "route_name",
+  "source_layer",
+  "source_atm_classification",
+  "geometry_status",
+  "geometry_confidence",
+  "needs_human_spot_check",
+  "source_ids",
+  "provenance_notes",
+  "uncertainty_notes",
+]);
+
+assert.equal(
+  atmRouteExtractionSchema.allowed_feature_values.geometry_status.includes(
+    "ambiguous-or-unextractable",
+  ),
+  true,
+);
+
 execFileSync("npm", ["run", "validate:sources"], { stdio: "pipe" });
 execFileSync("npm", ["run", "validate:destinations"], { stdio: "pipe" });
 
@@ -160,6 +195,21 @@ assert.match(bathSomerValleyExtractionNoteText, /best-fit/i);
 assert.match(bathSomerValleyExtractionNoteText, /ambigu/i);
 assert.match(bathSomerValleyExtractionNoteText, /not official reusable council GeoJSON/i);
 
+assert.equal(
+  existsSync("docs/product/full-banes-atm-extraction-plan.md"),
+  true,
+);
+const fullBanesExtractionPlan = await readFile(
+  "docs/product/full-banes-atm-extraction-plan.md",
+  "utf8",
+);
+const fullBanesExtractionPlanText = fullBanesExtractionPlan.replace(/\s+/g, " ");
+assert.match(fullBanesExtractionPlanText, /full B&NES ATM route extraction/i);
+assert.match(fullBanesExtractionPlanText, /data\/atm-route-extraction-schema\.json/i);
+assert.match(fullBanesExtractionPlanText, /geographic batch/i);
+assert.match(fullBanesExtractionPlanText, /ambiguous or unextractable/i);
+assert.match(fullBanesExtractionPlanText, /not official reusable council GeoJSON/i);
+
 assert.equal(sourceInventory.pilot_area, "Bath to Somer Valley");
 assert.equal(sourceInventory.review_status, "reviewed-for-mvp");
 assert.equal(
@@ -225,6 +275,114 @@ assert.match(
     "tmp-route-tests/atm-feature-missing-properties.geojson",
   ),
   /atm_route_id/,
+);
+
+await writeFile(
+  "tmp-route-tests/atm-routes-unextractable-feature.geojson",
+  `${JSON.stringify(
+    {
+      type: "FeatureCollection",
+      metadata: {
+        batch_id: "future-batch",
+        batch_name: "Future batch",
+        batch_area: "B&NES future batch",
+        extraction_status: "planned-batch",
+        geometry_precision: "unextractable",
+        geometry_status: "ambiguous-or-unextractable",
+        official_geometry: false,
+        source_summary: "Public ATM map context requires review.",
+        notes: "Planning fixture. This is not official reusable council GeoJSON.",
+      },
+      features: [
+        {
+          type: "Feature",
+          geometry: null,
+          properties: {
+            atm_route_id: "atm-future-ambiguous-route",
+            route_name: "Future ambiguous route",
+            source_layer: "atm-route",
+            source_atm_classification: "strategic",
+            geometry_status: "ambiguous-or-unextractable",
+            geometry_confidence: "unextractable",
+            needs_human_spot_check: true,
+            source_ids: ["banes-active-travel-masterplan-route-map"],
+            provenance_notes:
+              "The public ATM map identifies a route in this area.",
+            uncertainty_notes:
+              "The public map is too ambiguous to draw a best-fit geometry.",
+          },
+        },
+      ],
+    },
+    null,
+    2,
+  )}\n`,
+);
+validateAtmRoutes("tmp-route-tests/atm-routes-unextractable-feature.geojson");
+
+await writeFile(
+  "tmp-route-tests/atm-routes-unknown-source.geojson",
+  `${JSON.stringify(
+    {
+      type: "FeatureCollection",
+      metadata: {
+        batch_id: "future-batch",
+        batch_name: "Future batch",
+        batch_area: "B&NES future batch",
+        extraction_status: "planned-batch",
+        geometry_precision: "unextractable",
+        geometry_status: "ambiguous-or-unextractable",
+        official_geometry: false,
+        source_summary: "Public ATM map context requires review.",
+        notes: "Planning fixture. This is not official reusable council GeoJSON.",
+      },
+      features: [
+        {
+          type: "Feature",
+          geometry: null,
+          properties: {
+            atm_route_id: "atm-future-unknown-source",
+            route_name: "Future unknown source route",
+            source_layer: "atm-route",
+            source_atm_classification: "strategic",
+            geometry_status: "ambiguous-or-unextractable",
+            geometry_confidence: "unextractable",
+            needs_human_spot_check: true,
+            source_ids: ["unknown-source"],
+            provenance_notes:
+              "The public ATM map identifies a route in this area.",
+            uncertainty_notes:
+              "The public map is too ambiguous to draw a best-fit geometry.",
+          },
+        },
+      ],
+    },
+    null,
+    2,
+  )}\n`,
+);
+assert.match(
+  atmRoutesValidationFailure("tmp-route-tests/atm-routes-unknown-source.geojson"),
+  /unknown-source/,
+);
+
+await writeFile(
+  "tmp-route-tests/atm-routes-missing-batch-metadata.geojson",
+  `${JSON.stringify(
+    {
+      type: "FeatureCollection",
+      metadata: {},
+      features: [],
+    },
+    null,
+    2,
+  )}\n`,
+);
+assert.match(
+  atmRoutesValidationFailure(
+    "tmp-route-tests/atm-routes-missing-batch-metadata.geojson",
+  ),
+  /metadata\.batch_id/,
 );
 
 function validateRoutes(routeFile) {
@@ -591,30 +749,34 @@ for (const route of pilotRoutes.filter(
   assert.equal(route.route_geometry_status, "prototype-indicative");
   assert.match(route.route_geometry_notes, /prototype|indicative/i);
 }
-const { renderRouteMap } = await import("../src/route-map.mjs");
-const renderedRouteMap = renderRouteMap(pilotRoutes);
+const { hydrateLeafletRouteMap, renderRouteMap } = await import("../src/route-map.mjs");
+const renderedRouteMap = renderRouteMap(pilotRoutes, {
+  atmRoutesGeoJson: bathSomerValleyAtmRoutes,
+});
 const renderedRouteMapWithDestinations = renderRouteMap(pilotRoutes, {
+  atmRoutesGeoJson: bathSomerValleyAtmRoutes,
   destinations: pilotDestinations,
   showDestinations: true,
 });
 const renderedSelectedRouteMap = renderRouteMap(pilotRoutes, {
+  atmRoutesGeoJson: bathSomerValleyAtmRoutes,
   selectedRouteId: "prototype-a367-utility-corridor-hypothesis",
 });
 const renderedSelectedSchoolRouteMap = renderRouteMap(pilotRoutes, {
+  atmRoutesGeoJson: bathSomerValleyAtmRoutes,
   destinations: pilotDestinations,
   selectedRouteId: "prototype-somer-valley-school-access-review",
   showDestinations: true,
 });
 assert.match(renderedRouteMap, /Original ATM-style source evidence/i);
 assert.match(renderedRouteMap, /Simplified prototype layer/i);
-assert.match(renderedRouteMap, /class="route-sketch-map"/i);
-assert.match(renderedRouteMap, /viewBox="0 0 100 100"/i);
-assert.match(renderedRouteMap, /<path[^>]+class="route-sketch-line/i);
-assert.match(renderedRouteMap, /<path[^>]+data-route-id="prototype-a367-utility-corridor-hypothesis"/i);
-assert.match(renderedRouteMap, /Bath/i);
-assert.match(renderedRouteMap, /Peasedown St John/i);
-assert.match(renderedRouteMap, /Radstock/i);
-assert.match(renderedRouteMap, /Midsomer Norton/i);
+assert.match(renderedRouteMap, /data-leaflet-route-map/i);
+assert.match(renderedRouteMap, /OpenStreetMap contributors/i);
+assert.match(renderedRouteMap, /Source ATM\/context geometry/i);
+assert.match(renderedRouteMap, /7 checked-in best-fit lon\/lat features/i);
+assert.match(renderedRouteMap, /data-map-layer="source-context"/i);
+assert.match(renderedRouteMap, /data-map-layer="prototype-prioritisation"/i);
+assert.match(renderedRouteMap, /not official alignments/i);
 assert.match(renderedRouteMap, /data-route-layer="atm-background"/i);
 assert.match(renderedRouteMap, /data-route-layer="prototype-simplified"/i);
 assert.match(renderedRouteMap, /<button[^>]+data-route-id="/i);
@@ -632,6 +794,41 @@ assert.equal(
 assert.match(renderedRouteMap, /prototype-indicative/i);
 assert.match(renderedRouteMap, /manual-prototype-sketch/i);
 assert.match(renderedRouteMap, /not a final preferred alignment/i);
+
+const hydratedMap = hydrateRouteMapWithFakeLeaflet({
+  atmRoutesGeoJson: bathSomerValleyAtmRoutes,
+  routes: pilotRoutes,
+});
+assert.equal(hydratedMap.tileUrls[0], "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png");
+assert.equal(hydratedMap.geoJsonFeatureCounts[0], 7);
+assert.equal(hydratedMap.geoJsonFeatureCounts[1], 3);
+const somerValleyPrototypeFeature = hydratedMap.prototypeFeatures.find(
+  (feature) =>
+    feature.properties?.route_id ===
+    "prototype-somer-valley-school-access-review",
+);
+assert.deepEqual(
+  somerValleyPrototypeFeature.geometry.coordinates.slice(0, 2),
+  [
+    [-2.485, 51.285],
+    [-2.471, 51.287],
+  ],
+);
+assert.equal(
+  containsSegment(somerValleyPrototypeFeature.geometry.coordinates, [
+    -2.529,
+    51.298,
+  ], [
+    -2.448,
+    51.293,
+  ]),
+  false,
+);
+hydratedMap.prototypeRouteClickHandlers[0]();
+assert.equal(
+  hydratedMap.selectedRouteIds[0],
+  "prototype-a367-utility-corridor-hypothesis",
+);
 
 assert.match(renderedRouteMapWithDestinations, /School and key destination context/i);
 assert.match(renderedRouteMapWithDestinations, /data-destination-layer="pilot-destinations"/i);
@@ -738,6 +935,7 @@ assert.equal(existsSync("dist/app.mjs"), true);
 assert.equal(existsSync("dist/route-map.mjs"), true);
 assert.equal(existsSync("dist/data/pilot-routes.json"), true);
 assert.equal(existsSync("dist/data/pilot-destinations.json"), true);
+assert.equal(existsSync("dist/data/atm-routes-bath-somer-valley.geojson"), true);
 
 const page = await readFile("dist/index.html", "utf8");
 const visibleText = page.replace(/\s+/g, " ");
@@ -746,10 +944,13 @@ assert.match(page, /href="styles\.css"/i);
 assert.match(page, /type="module" src="app\.mjs"/i);
 
 const clientScript = await readFile("dist/app.mjs", "utf8");
-assert.match(clientScript, /import \{ renderRouteMap \}/i);
+assert.match(clientScript, /import \{ hydrateLeafletRouteMap, renderRouteMap \}/i);
 assert.match(clientScript, /pilot-routes\.json/i);
 assert.match(clientScript, /pilot-destinations\.json/i);
+assert.match(clientScript, /atm-routes-bath-somer-valley\.geojson/i);
+assert.match(clientScript, /leaflet@1\.9\.4/i);
 assert.match(clientScript, /innerHTML\s*=\s*renderRouteMap/i);
+assert.match(clientScript, /hydrateLeafletRouteMap/i);
 assert.match(clientScript, /addEventListener\("click"/i);
 assert.match(clientScript, /closest\("\[data-route-id\]"\)/i);
 assert.match(clientScript, /closest\("\[data-destination-toggle\]"\)/i);
@@ -832,5 +1033,107 @@ assert.doesNotMatch(
   firstReviewNoteText,
   /\d+\s*(%|percent|car-mile|car mile|school-run|school run|modal shift|funding eligibility)/i,
 );
+
+function hydrateRouteMapWithFakeLeaflet(options) {
+  const originalWindow = globalThis.window;
+  const tileUrls = [];
+  const geoJsonFeatureCounts = [];
+  const prototypeFeatures = [];
+  const prototypeRouteClickHandlers = [];
+  const selectedRouteIds = [];
+  const root = {
+    querySelector(selector) {
+      assert.equal(selector, "[data-leaflet-route-map]");
+      return {};
+    },
+  };
+
+  globalThis.window = {
+    L: {
+      map() {
+        return {
+          fitBounds(bounds, fitOptions) {
+            assert.deepEqual(bounds, [["bounds"]]);
+            assert.deepEqual(fitOptions, { padding: [18, 18] });
+          },
+        };
+      },
+      tileLayer(url, tileOptions) {
+        tileUrls.push(url);
+        assert.match(tileOptions.attribution, /OpenStreetMap contributors/i);
+        return {
+          addTo() {
+            return {};
+          },
+        };
+      },
+      geoJSON(featureCollection, geoJsonOptions = {}) {
+        geoJsonFeatureCounts.push(featureCollection.features.length);
+        if (
+          featureCollection.features.some(
+            (feature) =>
+              feature.properties?.source_layer === "prototype-prioritisation",
+          )
+        ) {
+          prototypeFeatures.push(...featureCollection.features);
+        }
+        for (const feature of featureCollection.features) {
+          const layer = {
+            on(eventName, handler) {
+              assert.equal(eventName, "click");
+              prototypeRouteClickHandlers.push(handler);
+            },
+          };
+          geoJsonOptions.onEachFeature?.(feature, layer);
+          geoJsonOptions.style?.(feature);
+        }
+        return {
+          addTo() {
+            return {};
+          },
+        };
+      },
+      featureGroup() {
+        return {
+          getBounds() {
+            return [["bounds"]];
+          },
+        };
+      },
+    },
+  };
+
+  try {
+    hydrateLeafletRouteMap(root, {
+      ...options,
+      onRouteSelect(routeId) {
+        selectedRouteIds.push(routeId);
+      },
+    });
+  } finally {
+    globalThis.window = originalWindow;
+  }
+
+  return {
+    geoJsonFeatureCounts,
+    prototypeFeatures,
+    prototypeRouteClickHandlers,
+    selectedRouteIds,
+    tileUrls,
+  };
+}
+
+function containsSegment(coordinates, start, end) {
+  return coordinates.some((coordinate, index) => {
+    const previous = coordinates[index - 1];
+    return (
+      previous &&
+      previous[0] === start[0] &&
+      previous[1] === start[1] &&
+      coordinate[0] === end[0] &&
+      coordinate[1] === end[1]
+    );
+  });
+}
 
 await rm("tmp-route-tests", { recursive: true, force: true });

--- a/scripts/validate-atm-routes.mjs
+++ b/scripts/validate-atm-routes.mjs
@@ -7,27 +7,39 @@ if (!geoJsonFile) {
   process.exit(1);
 }
 
+const schema = JSON.parse(
+  await readFile(
+    new URL("../data/atm-route-extraction-schema.json", import.meta.url),
+    "utf8",
+  ),
+);
+const sourceInventory = JSON.parse(
+  await readFile(
+    new URL("../data/pilot-source-inventory.json", import.meta.url),
+    "utf8",
+  ),
+);
 const geoJson = JSON.parse(await readFile(geoJsonFile, "utf8"));
 const errors = [];
+const knownSourceIds = new Set(
+  sourceInventory.sources.map((source) => source.id),
+);
 const allowedGeometryTypes = new Set(["LineString", "MultiLineString"]);
-const allowedSourceLayers = new Set([
-  "atm-route",
-  "context-greenway",
-  "context-route",
-]);
-const allowedGeometryConfidence = new Set(["high", "medium", "low"]);
-const requiredProperties = [
-  "atm_route_id",
-  "route_name",
-  "source_layer",
-  "source_atm_classification",
-  "geometry_status",
-  "geometry_confidence",
-  "needs_human_spot_check",
-  "source_ids",
-  "provenance_notes",
-  "uncertainty_notes",
-];
+const allowedSourceLayers = new Set(schema.allowed_feature_values.source_layer);
+const allowedGeometryConfidence = new Set(
+  schema.allowed_feature_values.geometry_confidence,
+);
+const allowedFeatureGeometryStatuses = new Set(
+  schema.allowed_feature_values.geometry_status,
+);
+const allowedCollectionValues = Object.fromEntries(
+  Object.entries(schema.allowed_collection_values).map(([property, values]) => [
+    property,
+    new Set(values),
+  ]),
+);
+const requiredProperties = schema.required_feature_properties;
+const requiredMetadataProperties = schema.required_collection_metadata;
 const officialGeometryPattern =
   /\bofficial\s+(reusable\s+)?(council\s+)?(geojson|geometry)\b/i;
 const bounds = {
@@ -45,6 +57,44 @@ if (!Array.isArray(geoJson.features)) {
   errors.push("ATM route dataset must include a features array.");
 }
 
+const metadata = geoJson.metadata;
+if (
+  metadata === null ||
+  typeof metadata !== "object" ||
+  Array.isArray(metadata)
+) {
+  errors.push("ATM route dataset must include metadata object.");
+} else {
+  for (const property of requiredMetadataProperties) {
+    if (!(property in metadata)) {
+      errors.push(`metadata.${property} is required.`);
+    } else if (
+      typeof metadata[property] === "string" &&
+      metadata[property].trim() === ""
+    ) {
+      errors.push(`metadata.${property} cannot be blank.`);
+    }
+  }
+
+  for (const [property, allowedValues] of Object.entries(
+    allowedCollectionValues,
+  )) {
+    if (property in metadata && !allowedValues.has(metadata[property])) {
+      errors.push(
+        `metadata.${property} has unsupported value "${metadata[property]}".`,
+      );
+    }
+  }
+
+  if (metadata.official_geometry !== false) {
+    errors.push("metadata.official_geometry must be false.");
+  }
+
+  if (impliesOfficialGeometry(metadata.notes ?? "")) {
+    errors.push("metadata.notes must not imply official reusable geometry.");
+  }
+}
+
 if (Array.isArray(geoJson.features)) {
   geoJson.features.forEach((feature, featureIndex) => {
     const featureLabel =
@@ -55,7 +105,9 @@ if (Array.isArray(geoJson.features)) {
       return;
     }
 
-    if (!allowedGeometryTypes.has(feature.geometry?.type)) {
+    if (feature.geometry === null) {
+      // Null geometry is valid GeoJSON for routes that are recorded but unsafe to draw.
+    } else if (!allowedGeometryTypes.has(feature.geometry?.type)) {
       errors.push(
         `${featureLabel}: geometry must be LineString or MultiLineString`,
       );
@@ -93,7 +145,9 @@ if (Array.isArray(geoJson.features)) {
         typeof properties[property] === "string" &&
         properties[property].trim() === ""
       ) {
-        errors.push(`${featureLabel}: required property "${property}" cannot be blank`);
+        errors.push(
+          `${featureLabel}: required property "${property}" cannot be blank`,
+        );
       }
     }
 
@@ -108,10 +162,10 @@ if (Array.isArray(geoJson.features)) {
 
     if (
       "geometry_status" in properties &&
-      properties.geometry_status !== "best-fit-extracted-from-public-atm-map"
+      !allowedFeatureGeometryStatuses.has(properties.geometry_status)
     ) {
       errors.push(
-        `${featureLabel}: geometry_status must be "best-fit-extracted-from-public-atm-map"`,
+        `${featureLabel}: unsupported geometry_status "${properties.geometry_status}"`,
       );
     }
 
@@ -133,8 +187,44 @@ if (Array.isArray(geoJson.features)) {
       );
     }
 
-    if (!Array.isArray(properties.source_ids) || properties.source_ids.length === 0) {
+    if (
+      properties.geometry_confidence === "unextractable" &&
+      properties.needs_human_spot_check !== true
+    ) {
+      errors.push(
+        `${featureLabel}: unextractable features must set needs_human_spot_check true`,
+      );
+    }
+
+    if (
+      feature.geometry === null &&
+      properties.geometry_status !== "ambiguous-or-unextractable"
+    ) {
+      errors.push(
+        `${featureLabel}: null geometry must use geometry_status "ambiguous-or-unextractable"`,
+      );
+    }
+
+    if (
+      feature.geometry === null &&
+      properties.geometry_confidence !== "unextractable"
+    ) {
+      errors.push(
+        `${featureLabel}: null geometry must use geometry_confidence "unextractable"`,
+      );
+    }
+
+    if (
+      !Array.isArray(properties.source_ids) ||
+      properties.source_ids.length === 0
+    ) {
       errors.push(`${featureLabel}: source_ids must be a non-empty array`);
+    } else {
+      for (const sourceId of properties.source_ids) {
+        if (!knownSourceIds.has(sourceId)) {
+          errors.push(`${featureLabel}: unknown source_id "${sourceId}"`);
+        }
+      }
     }
 
     if (

--- a/src/app.mjs
+++ b/src/app.mjs
@@ -1,25 +1,46 @@
-import { renderRouteMap } from "./route-map.mjs";
+import { hydrateLeafletRouteMap, renderRouteMap } from "./route-map.mjs";
 
 const routeDatasetUrl = "data/pilot-routes.json";
 const destinationDatasetUrl = "data/pilot-destinations.json";
+const atmRoutesGeoJsonUrl = "data/atm-routes-bath-somer-valley.geojson";
+const leafletCssUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css";
+const leafletScriptUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js";
 const routeMap = document.querySelector("#route-map");
 
 if (routeMap) {
-  const [routeResponse, destinationResponse] = await Promise.all([
-    fetch(routeDatasetUrl),
-    fetch(destinationDatasetUrl),
-  ]);
+  const [routeResponse, destinationResponse, atmRoutesGeoJsonResponse] =
+    await Promise.all([
+      fetch(routeDatasetUrl),
+      fetch(destinationDatasetUrl),
+      fetch(atmRoutesGeoJsonUrl),
+    ]);
   const routes = await routeResponse.json();
   const destinations = await destinationResponse.json();
+  const atmRoutesGeoJson = await atmRoutesGeoJsonResponse.json();
+  const leafletReady = loadLeaflet();
   let selectedRouteId = null;
   let showDestinations = true;
 
   function renderSelectedRouteMap() {
     routeMap.innerHTML = renderRouteMap(routes, {
+      atmRoutesGeoJson,
       destinations,
       selectedRouteId,
       showDestinations,
     });
+    leafletReady
+      .then(() => {
+        hydrateLeafletRouteMap(routeMap, {
+          atmRoutesGeoJson,
+          routes,
+          selectedRouteId,
+          onRouteSelect(routeId) {
+            selectedRouteId = routeId;
+            renderSelectedRouteMap();
+          },
+        });
+      })
+      .catch(() => {});
   }
 
   routeMap.addEventListener("click", (event) => {
@@ -55,4 +76,32 @@ if (routeMap) {
   });
 
   renderSelectedRouteMap();
+}
+
+function loadLeaflet() {
+  if (!globalThis.window || globalThis.window.L || !document.createElement) {
+    return Promise.resolve();
+  }
+
+  if (!document.querySelector(`link[href="${leafletCssUrl}"]`)) {
+    const stylesheet = document.createElement("link");
+    stylesheet.rel = "stylesheet";
+    stylesheet.href = leafletCssUrl;
+    document.head.append(stylesheet);
+  }
+
+  if (globalThis.window.__atmLeafletLoading) {
+    return globalThis.window.__atmLeafletLoading;
+  }
+
+  globalThis.window.__atmLeafletLoading = new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = leafletScriptUrl;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error("Unable to load Leaflet"));
+    document.head.append(script);
+  });
+
+  return globalThis.window.__atmLeafletLoading;
 }

--- a/src/route-map.mjs
+++ b/src/route-map.mjs
@@ -2,6 +2,7 @@ import { formatRouteDetail } from "./route-details.mjs";
 import { styleRouteForMap } from "./route-styles.mjs";
 
 export function renderRouteMap(routes, options = {}) {
+  const atmRoutesGeoJson = options.atmRoutesGeoJson;
   const destinations = Array.isArray(options.destinations)
     ? options.destinations
     : [];
@@ -18,7 +19,7 @@ export function renderRouteMap(routes, options = {}) {
 
   return [
     "<section class=\"route-map\" aria-label=\"Pilot route map\">",
-    renderSketchMap(routes, selectedRoute),
+    renderLeafletMap(atmRoutesGeoJson),
     "<div class=\"route-layer route-layer-background\" data-route-layer=\"atm-background\">",
     "<h2>Original ATM-style source evidence</h2>",
     ...backgroundRoutes.map((route) => renderRoute(route, selectedRoute)),
@@ -34,86 +35,236 @@ export function renderRouteMap(routes, options = {}) {
   ].join("");
 }
 
-function renderSketchMap(routes, selectedRoute) {
-  const routesWithGeometry = routes.filter((route) =>
-    Array.isArray(route.map_geometry?.points),
-  );
+export function hydrateLeafletRouteMap(root, options = {}) {
+  const mapElement = root?.querySelector?.("[data-leaflet-route-map]");
+  const leaflet = globalThis.window?.L;
 
-  if (routesWithGeometry.length === 0) {
-    return "";
+  if (!mapElement || !leaflet) {
+    return;
   }
 
+  const atmRoutesGeoJson = options.atmRoutesGeoJson;
+  const sourceFeatures = sourceContextFeatures(atmRoutesGeoJson);
+  const prototypeFeatures = prototypePrioritisationFeatures(
+    options.routes ?? [],
+    atmRoutesGeoJson,
+  );
+
+  if (sourceFeatures.length === 0 && prototypeFeatures.length === 0) {
+    return;
+  }
+
+  const map = leaflet.map(mapElement, {
+    scrollWheelZoom: false,
+  });
+
+  leaflet
+    .tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "&copy; OpenStreetMap contributors",
+      maxZoom: 19,
+    })
+    .addTo(map);
+
+  const sourceLayer = leaflet
+    .geoJSON(
+      {
+        type: "FeatureCollection",
+        features: sourceFeatures,
+      },
+      {
+        style(feature) {
+          return styleSourceFeature(feature);
+        },
+      },
+    )
+    .addTo(map);
+
+  const prototypeLayer = leaflet
+    .geoJSON(
+      {
+        type: "FeatureCollection",
+        features: prototypeFeatures,
+      },
+      {
+        onEachFeature(feature, layer) {
+          const routeId = feature.properties?.route_id;
+          if (!routeId) {
+            return;
+          }
+
+          layer.on("click", () => {
+            options.onRouteSelect?.(routeId);
+          });
+        },
+        style(feature) {
+          return stylePrototypeFeature(
+            feature,
+            feature.properties?.route_id === options.selectedRouteId,
+          );
+        },
+      },
+    )
+    .addTo(map);
+
+  const featureGroup = leaflet.featureGroup([sourceLayer, prototypeLayer]);
+  map.fitBounds(featureGroup.getBounds(), {
+    padding: [18, 18],
+  });
+}
+
+function renderLeafletMap(atmRoutesGeoJson) {
+  const sourceFeatureCount = sourceContextFeatures(atmRoutesGeoJson).length;
+
   return [
-    "<div class=\"route-sketch\" aria-label=\"Indicative route map sketch\">",
-    "<svg class=\"route-sketch-map\" viewBox=\"0 0 100 100\" role=\"img\" aria-labelledby=\"route-sketch-title route-sketch-description\">",
-    "<title id=\"route-sketch-title\">Bath to Somer Valley indicative route sketch</title>",
-    "<desc id=\"route-sketch-description\">Clickable indicative route lines showing original ATM-style source evidence and simplified prototype corridors. Lines are sketch geometry, not official route alignments.</desc>",
-    renderSketchBackground(),
-    ...routesWithGeometry.map((route) =>
-      renderSketchRoute(route, selectedRoute),
-    ),
-    renderSketchLabel("Bath", 12, 86),
-    renderSketchLabel("Odd Down", 29, 64),
-    renderSketchLabel("Peasedown St John", 45, 45),
-    renderSketchLabel("Radstock", 67, 62),
-    renderSketchLabel("Midsomer Norton", 73, 88),
-    "</svg>",
-    "<p class=\"route-sketch-note\">Indicative sketch only: original ATM-style source evidence is shown as pale background context and prototype routes are shown above it. These lines are not official alignments.</p>",
+    "<div class=\"leaflet-map-shell\" aria-label=\"Bath to Somer Valley interactive map\">",
+    "<div class=\"leaflet-route-map\" data-leaflet-route-map role=\"application\" aria-label=\"Leaflet map with OpenStreetMap streets basemap\"></div>",
+    "<div class=\"leaflet-layer-summary\" aria-label=\"Map layer summary\">",
+    "<p data-map-layer=\"source-context\"><strong>Source ATM/context geometry:</strong> ",
+    sourceFeatureCount,
+    " checked-in best-fit lon/lat features from the Bath to Somer Valley ATM extraction.</p>",
+    "<p data-map-layer=\"prototype-prioritisation\"><strong>Prototype hypothesis/prioritisation layers:</strong> selectable review corridors drawn separately above the source/context evidence.</p>",
+    "</div>",
+    "<p class=\"route-sketch-note\">Leaflet/OpenStreetMap map. Basemap attribution: OpenStreetMap contributors. Geometry is indicative review-map evidence and prototype hypothesis only; lines are not official alignments.</p>",
     "</div>",
   ].join("");
 }
 
-function renderSketchBackground() {
-  return [
-    "<rect class=\"route-sketch-base\" x=\"0\" y=\"0\" width=\"100\" height=\"100\"></rect>",
-    "<path class=\"route-sketch-context route-sketch-context-a\" d=\"M8 30 C22 24 33 24 45 33 S68 44 91 36\"></path>",
-    "<path class=\"route-sketch-context route-sketch-context-b\" d=\"M11 82 C25 75 36 70 49 73 S72 86 90 79\"></path>",
-    "<path class=\"route-sketch-road\" d=\"M17 80 C31 62 47 49 62 38 S78 28 87 22\"></path>",
-  ].join("");
+function sourceContextFeatures(atmRoutesGeoJson) {
+  return featureCollectionFeatures(atmRoutesGeoJson).filter((feature) =>
+    ["atm-route", "context-greenway"].includes(feature.properties?.source_layer),
+  );
 }
 
-function renderSketchRoute(route, selectedRoute) {
+function featureCollectionFeatures(geoJson) {
+  return geoJson?.type === "FeatureCollection" && Array.isArray(geoJson.features)
+    ? geoJson.features
+    : [];
+}
+
+function prototypePrioritisationFeatures(routes, atmRoutesGeoJson) {
+  const sourceFeatures = featureCollectionFeatures(atmRoutesGeoJson);
+  const sourceById = new Map(
+    sourceFeatures.map((feature) => [
+      feature.properties?.atm_route_id,
+      feature,
+    ]),
+  );
+
+  return routes
+    .filter((route) => route.route_layer === "prototype-simplified")
+    .map((route) => prototypeFeature(route, sourceById))
+    .filter(Boolean);
+}
+
+function prototypeFeature(route, sourceById) {
+  const coordinates = prototypeCoordinatesByRouteId(route.route_id, sourceById);
+
+  if (coordinates.length < 2) {
+    return null;
+  }
+
+  return {
+    type: "Feature",
+    geometry: {
+      type: "LineString",
+      coordinates,
+    },
+    properties: {
+      route_id: route.route_id,
+      route_name: route.route_name,
+      source_layer: "prototype-prioritisation",
+    },
+  };
+}
+
+function prototypeCoordinatesByRouteId(routeId, sourceById) {
+  if (routeId === "prototype-a367-utility-corridor-hypothesis") {
+    return compactLineCoordinates([
+      ...reverseCoordinates(
+        sourceById.get("atm-6-8A-peasedown-bath-strategic"),
+      ),
+      ...coordinatesWithoutFirst(
+        reverseCoordinates(
+          sourceById.get("atm-5-6A-a367-bristol-road-strategic"),
+        ),
+      ),
+      ...coordinatesWithoutFirst(
+        sourceById.get("atm-5-3A-a362-radstock-midsomer-farrington"),
+      ),
+    ]);
+  }
+
+  if (routeId === "prototype-somer-valley-school-access-review") {
+    return compactLineCoordinates([
+      ...sourceById.get("context-norton-radstock-greenway-five-arches")?.geometry
+        ?.coordinates ?? [],
+      ...coordinatesWithoutFirst(
+        sourceById.get("atm-5-3A-a362-radstock-midsomer-farrington"),
+      ),
+    ]);
+  }
+
+  if (routeId === "prototype-greenway-utility-comparison") {
+    return compactLineCoordinates(
+      sourceById.get("context-ncn24-two-tunnels-colliers-way")?.geometry
+        ?.coordinates ?? [],
+    );
+  }
+
+  return [];
+}
+
+function reverseCoordinates(feature) {
+  return [...(feature?.geometry?.coordinates ?? [])].reverse();
+}
+
+function coordinatesWithoutFirst(featureOrCoordinates) {
+  const coordinates = Array.isArray(featureOrCoordinates)
+    ? featureOrCoordinates
+    : featureOrCoordinates?.geometry?.coordinates;
+
+  return coordinates?.slice(1) ?? [];
+}
+
+function compactLineCoordinates(coordinates) {
+  return coordinates.filter((coordinate, index) => {
+    const previous = coordinates[index - 1];
+    return (
+      Array.isArray(coordinate) &&
+      coordinate.length >= 2 &&
+      (!previous ||
+        previous[0] !== coordinate[0] ||
+        previous[1] !== coordinate[1])
+    );
+  });
+}
+
+function styleSourceFeature(feature) {
+  const isGreenway = feature.properties?.source_layer === "context-greenway";
+
+  return {
+    color: isGreenway ? "#4f7f52" : "#667788",
+    dashArray: isGreenway ? "4 6" : "2 4",
+    opacity: 0.68,
+    weight: isGreenway ? 4 : 5,
+  };
+}
+
+function stylePrototypeFeature(feature, isSelected) {
+  const route = {
+    route_layer: "prototype-simplified",
+    network_status: isSelected ? "preferred" : "needs-review",
+    modal_shift_potential: "unknown",
+    route_id: feature.properties?.route_id,
+  };
   const style = styleRouteForMap(route);
-  const isSelected = selectedRoute?.route_id === route.route_id;
 
-  return [
-    "<path class=\"route-sketch-line",
-    route.route_layer === "atm-background"
-      ? " route-sketch-line-background"
-      : " route-sketch-line-prototype",
-    isSelected ? " route-sketch-line-selected" : "",
-    "\" d=\"",
-    renderSketchPath(route.map_geometry.points),
-    "\" style=\"",
-    renderRouteStyle(style),
-    "\" data-route-id=\"",
-    escapeHtml(route.route_id),
-    "\" data-route-layer=\"",
-    escapeHtml(route.route_layer),
-    "\" tabindex=\"0\" role=\"button\" aria-controls=\"route-detail\" aria-pressed=\"",
-    isSelected ? "true" : "false",
-    "\" aria-label=\"Review ",
-    escapeHtml(route.route_name),
-    "\"></path>",
-  ].join("");
-}
-
-function renderSketchPath(points) {
-  return points
-    .map(([x, y], index) => `${index === 0 ? "M" : "L"} ${x} ${y}`)
-    .join(" ");
-}
-
-function renderSketchLabel(label, x, y) {
-  return [
-    "<text class=\"route-sketch-label\" x=\"",
-    x,
-    "\" y=\"",
-    y,
-    "\">",
-    escapeHtml(label),
-    "</text>",
-  ].join("");
+  return {
+    color: style.stroke,
+    dashArray: style.strokeDasharray === "none" ? undefined : style.strokeDasharray,
+    opacity: isSelected ? 1 : style.strokeOpacity,
+    weight: isSelected ? style.strokeWidth + 2 : style.strokeWidth,
+  };
 }
 
 function renderRoute(route, selectedRoute) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -197,6 +197,10 @@ h3 {
     min-height: 420px;
   }
 
+  .leaflet-layer-summary {
+    grid-template-columns: 1fr;
+  }
+
   h1 {
     font-size: 2.25rem;
   }
@@ -207,6 +211,38 @@ h3 {
   width: min(100%, 960px);
   gap: 18px;
   text-align: left;
+}
+
+.leaflet-map-shell {
+  display: grid;
+  gap: 10px;
+}
+
+.leaflet-route-map {
+  width: 100%;
+  min-height: 420px;
+  overflow: hidden;
+  border: 1px solid #cddce5;
+  border-radius: 8px;
+  background: #dce8ee;
+}
+
+.leaflet-layer-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.leaflet-layer-summary p {
+  min-height: 100%;
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid #d7e0e7;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #425466;
+  font-size: 0.88rem;
+  line-height: 1.45;
 }
 
 .route-sketch {


### PR DESCRIPTION
## Summary
- Add a Leaflet/OpenStreetMap visual companion using the checked-in Bath to Somer Valley ATM GeoJSON
- Keep source/context geometry visually separate from prototype prioritisation lines and preserve caveats
- Add the full B&NES extraction schema, validator checks, and batch plan scaffold

## Verification
- npm test
- npm run validate:atm-routes -- data/atm-routes-bath-somer-valley.geojson
- git diff --check
- Visual sign-off via local preview at http://localhost:4173/

Closes #19.
Advances #20.